### PR TITLE
chore: update Docker image tags to v0.8.0-alpha.1

### DIFF
--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -117,9 +117,9 @@ docker compose down -v
 |---------|-------|-------|---------|
 | postgres | `postgres:17` | (internal) | Schema, config, and audit storage |
 | redis | `redis:7` | (internal) | Cache invalidation + real-time pub/sub |
-| decree-server | `ghcr.io/opendecree/decree:main` | (internal) | Core config management |
-| seed | `ghcr.io/opendecree/decree-cli:main` | — | Init container: loads schema from file |
-| admin | `ghcr.io/opendecree/decree-ui:main` | 3000 | Admin GUI (nginx + React SPA) |
+| decree-server | `ghcr.io/opendecree/decree:0.8.0-alpha.1` | (internal) | Core config management |
+| seed | `ghcr.io/opendecree/decree-cli:0.8.0-alpha.1` | — | Init container: loads schema from file |
+| admin | `ghcr.io/opendecree/decree-ui:0.8.0-alpha.1` | 3000 | Admin GUI (nginx + React SPA) |
 | payroll-service | Built from `./service` | 4000 | Demo app (Go + WebSocket) |
 
 ### Decree Server Environment Variables

--- a/quickstart/docker-compose.yml
+++ b/quickstart/docker-compose.yml
@@ -50,7 +50,7 @@ services:
   # The core config management service. Runs database migrations automatically.
   # Exposes gRPC (:9090) for SDKs and REST (:8080) for the admin UI / curl.
   decree-server:
-    image: ghcr.io/opendecree/decree:main
+    image: ghcr.io/opendecree/decree:0.8.0-alpha.1
     depends_on:
       postgres:
         condition: service_healthy
@@ -73,7 +73,7 @@ services:
   # Runs once on startup. The seed is idempotent — safe to re-run after
   # editing seed.yaml (existing values preserved, new fields added).
   seed:
-    image: ghcr.io/opendecree/decree-cli:main
+    image: ghcr.io/opendecree/decree-cli:0.8.0-alpha.1
     depends_on:
       decree-server:
         condition: service_started
@@ -90,7 +90,7 @@ services:
   # LAYOUT_MODE=single-tenant hides the schema/tenant navigation —
   # users just see config fields, not the underlying schema system.
   admin:
-    image: ghcr.io/opendecree/decree-ui:main
+    image: ghcr.io/opendecree/decree-ui:0.8.0-alpha.1
     depends_on:
       decree-server:
         condition: service_started


### PR DESCRIPTION
Updates quickstart docker-compose and README to reference decree v0.8.0-alpha.1 images.