### PR TITLE
fix: rename syntax → spec_version in quickstart seed

### DIFF
--- a/quickstart/seed.yaml
+++ b/quickstart/seed.yaml
@@ -1,4 +1,4 @@
-syntax: v1
+spec_version: v1
 schema:
   name: payroll-service
   description: Payroll processing configuration for the demo service


### PR DESCRIPTION
Post-[decree#118](https://github.com/opendecree/decree/pull/130) cleanup. The top-level YAML key `syntax:` was renamed to `spec_version:` in the decree schema/config/seed format. Without this change, `decree seed quickstart/seed.yaml` against a decree built from main fails with:

> spec_version is required

## Test plan
- [ ] `decree seed quickstart/seed.yaml` against a locally-built decree from main succeeds (manual check recommended, no in-repo CI covers this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)