### PR TITLE
docs: link to org Discussions community hub

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Community Discussions
+    url: https://github.com/orgs/opendecree/discussions
+    about: Questions, ideas, and show-and-tell — ask here before filing an issue.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Think of it as "database migrations, but for your business config."
 
 ## Want to Contribute a Demo?
 
-We'd love that. Check out [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines and the demo README template. If you have an idea but aren't sure where to start, open a [Discussion](https://github.com/opendecree/decree/discussions) in the main repo.
+We'd love that. Check out [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines and the demo README template. If you have an idea but aren't sure where to start, open a [Discussion](https://github.com/orgs/opendecree/discussions) on our community hub.
 
 ## What's Next?
 
@@ -65,6 +65,10 @@ We'd love that. Check out [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines and 
 - [Python SDK](https://github.com/opendecree/decree-python) — `pip install opendecree`
 - [TypeScript SDK](https://github.com/opendecree/decree-typescript) — `npm install @opendecree/sdk`
 - [Admin GUI](https://github.com/opendecree/decree-ui) — browser-based config management
+
+## Questions?
+
+Head to [OpenDecree Discussions](https://github.com/orgs/opendecree/discussions) — our community hub covers all OpenDecree repos.
 
 ## License
 


### PR DESCRIPTION
## Summary
- Add `.github/ISSUE_TEMPLATE/config.yml` `contact_links` pointing to `https://github.com/orgs/opendecree/discussions`
- Add "Questions?" section to README linking the org Discussions hub
- Retarget existing contribute-a-demo discussion link from `decree/discussions` to the org hub

Part of opendecree/decree#167 — single community surface across all OpenDecree repos.

## Test plan
- [ ] "New issue" page shows the Community Discussions link
- [ ] README renders "Questions?" section correctly on GitHub
- [ ] Contribute-a-demo section points to org hub

🤖 Generated with [Claude Code](https://claude.com/claude-code)