### PR TITLE
chore: add dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,43 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /quickstart/service
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - ci
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: docker
+    directory: /quickstart/service
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - ci
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - ci
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## Summary
- Enable weekly Dependabot version bump PRs
- Ecosystems: gomod (1) + docker (1) + github-actions
- Minor + patch grouped; majors stay separate
- `open-pull-requests-limit: 5` per ecosystem; labels `dependencies`, `ci`

## Test plan
- [x] YAML parsed via `python3 yaml.safe_load`
- [ ] After merge: confirm Dependabot picks up config

Part of opendecree/decree#148

🤖 Generated with [Claude Code](https://claude.com/claude-code)