### PR TITLE
ci: add stale bot for inactive issues and PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,47 @@
+name: Stale issues and PRs
+
+# Daily sweep: marks inactive issues/PRs as stale and eventually closes
+# them. The `keep` label opts an item out entirely; `good first issue`
+# and `bug` are also exempt for issues. opendecree/decree#162.
+#
+# Tuning happens here per-repo so each project can adjust independently
+# if traffic patterns diverge.
+
+on:
+  schedule:
+    - cron: '30 1 * * *'  # daily 01:30 UTC
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: >
+            This issue has been inactive for 60 days and is being marked
+            stale. It will be closed in 14 days unless there is new
+            activity. Add the `keep` label to opt out of future sweeps.
+          stale-pr-message: >
+            This PR has been inactive for 30 days and is being marked
+            stale. It will be closed in 7 days unless there is new
+            activity. Add the `keep` label to opt out of future sweeps.
+          close-issue-message: >
+            Closing for inactivity. Reopen if this is still relevant.
+          close-pr-message: >
+            Closing for inactivity. Reopen if this is still relevant.
+          stale-issue-label: stale
+          stale-pr-label: stale
+          days-before-issue-stale: 60
+          days-before-issue-close: 14
+          days-before-pr-stale: 30
+          days-before-pr-close: 7
+          exempt-issue-labels: 'keep,good first issue,bug'
+          exempt-pr-labels: 'keep'
+          close-issue-reason: not_planned
+          operations-per-run: 100


### PR DESCRIPTION
## Summary

- Adds a daily `actions/stale@v9` sweep matching the policy in opendecree/decree#162: 60d stale / 14d close for issues, 30d stale / 7d close for PRs.
- Exempt labels: `keep` (both), `good first issue` and `bug` for issues. The `keep` and `good first issue` labels have been pre-created in this repo.
- Self-contained workflow rather than a reusable in `opendecree/.github` so each repo can tune independently. Tracking issue stays in the decree repo.

## Test plan

- [ ] Manual `workflow_dispatch` from the Actions tab post-merge as a smoke test
- [ ] First scheduled run executes cleanly (next 01:30 UTC)

Refs opendecree/decree#162.

🤖 Generated with [Claude Code](https://claude.com/claude-code)