### PR TITLE
chore: bump decree images to v0.11.0-alpha.1

### DIFF
--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -117,8 +117,8 @@ docker compose down -v
 |---------|-------|-------|---------|
 | postgres | `postgres:17` | (internal) | Schema, config, and audit storage |
 | redis | `redis:7` | (internal) | Cache invalidation + real-time pub/sub |
-| decree-server | `ghcr.io/opendecree/decree:0.10.0-alpha.1` | (internal) | Core config management |
-| seed | `ghcr.io/opendecree/decree-cli:0.10.0-alpha.1` | — | Init container: loads schema from file |
+| decree-server | `ghcr.io/opendecree/decree:0.11.0-alpha.1` | (internal) | Core config management |
+| seed | `ghcr.io/opendecree/decree-cli:0.11.0-alpha.1` | — | Init container: loads schema from file |
 | admin | `ghcr.io/opendecree/decree-ui:0.1.0-alpha.1` | 3000 | Admin GUI (nginx + React SPA) |
 | payroll-service | Built from `./service` | 4000 | Demo app (Go + WebSocket) |
 

--- a/quickstart/docker-compose.yml
+++ b/quickstart/docker-compose.yml
@@ -50,7 +50,7 @@ services:
   # The core config management service. Runs database migrations automatically.
   # Exposes gRPC (:9090) for SDKs and REST (:8080) for the admin UI / curl.
   decree-server:
-    image: ghcr.io/opendecree/decree:0.10.0-alpha.1
+    image: ghcr.io/opendecree/decree:0.11.0-alpha.1
     depends_on:
       postgres:
         condition: service_healthy
@@ -73,7 +73,7 @@ services:
   # Runs once on startup. The seed is idempotent — safe to re-run after
   # editing seed.yaml (existing values preserved, new fields added).
   seed:
-    image: ghcr.io/opendecree/decree-cli:0.10.0-alpha.1
+    image: ghcr.io/opendecree/decree-cli:0.11.0-alpha.1
     depends_on:
       decree-server:
         condition: service_started


### PR DESCRIPTION
Bumps `decree` and `decree-cli` image tags in `quickstart/docker-compose.yml` and `quickstart/README.md` to `0.11.0-alpha.1`.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)