### PR TITLE
chore(deps): ignore grpc >= 1.81.0 for quickstart/service

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,10 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      # quickstart/service is go 1.24; grpc 1.81+ requires go 1.25.
+      - dependency-name: "google.golang.org/grpc"
+        versions: [">=1.81.0"]
 
   - package-ecosystem: docker
     directory: /quickstart/service


### PR DESCRIPTION
## Summary
- grpc 1.81.0 raised its minimum Go version to 1.25, but `quickstart/service` is pinned to go 1.24.
- Without this ignore rule, dependabot would open PRs that break the build for that module.
- Holds grpc at 1.80.x until we explicitly raise the go floor.

## Test plan
- Verify dependabot no longer opens grpc 1.81+ PRs for `quickstart/service`

🤖 Generated with [Claude Code](https://claude.com/claude-code)