### PR TITLE
feat(rest-walkthrough): add curl-only REST API demo

### DIFF
--- a/rest-walkthrough/README.md
+++ b/rest-walkthrough/README.md
@@ -1,0 +1,238 @@
+# REST Walkthrough
+
+> Drive the full OpenDecree API with nothing but `curl`. No SDK, no language runtime — just HTTP.
+
+## What you'll learn
+
+- How to create a schema and publish it
+- How to create a tenant and set config values
+- How to read individual fields and the full config snapshot
+- How to watch for real-time changes via server-sent events
+
+## Prerequisites
+
+- Docker and Docker Compose
+- `curl` and `jq`
+
+## Start the stack
+
+```bash
+docker compose up -d
+```
+
+Wait a few seconds for the database migrations to finish, then confirm the server is up:
+
+```bash
+curl -s http://localhost:8080/v1/server/info | jq .
+```
+
+Expected output includes `"version"` and `"commit"`.
+
+---
+
+## Step 1 — Create a schema
+
+A schema defines the shape of your configuration: field names, types, and constraints.
+
+```bash
+SCHEMA=$(curl -s -X POST http://localhost:8080/v1/schemas \
+  -H "Content-Type: application/json" \
+  -H "x-subject: walkthrough" \
+  -d '{
+    "name": "app-config",
+    "description": "Runtime configuration for a web application",
+    "fields": [
+      {
+        "path": "app.maintenance_mode",
+        "type": "FIELD_TYPE_BOOL",
+        "description": "Disable traffic during maintenance windows"
+      },
+      {
+        "path": "app.max_connections",
+        "type": "FIELD_TYPE_INT",
+        "description": "Maximum concurrent database connections",
+        "constraints": { "minimum": 1, "maximum": 1000 }
+      },
+      {
+        "path": "app.rate_limit_rps",
+        "type": "FIELD_TYPE_NUMBER",
+        "description": "API rate limit (requests per second)",
+        "constraints": { "minimum": 0 }
+      },
+      {
+        "path": "app.support_url",
+        "type": "FIELD_TYPE_STRING",
+        "description": "URL shown to users on error pages"
+      }
+    ]
+  }')
+
+echo "$SCHEMA" | jq .
+SCHEMA_ID=$(echo "$SCHEMA" | jq -r '.schema.id')
+echo "Schema ID: $SCHEMA_ID"
+```
+
+The schema is created as **version 1** in draft state — not yet usable by tenants.
+
+---
+
+## Step 2 — Publish the schema
+
+Publishing locks the version and makes it available for tenant assignment.
+
+```bash
+curl -s -X POST "http://localhost:8080/v1/schemas/${SCHEMA_ID}/publish" \
+  -H "Content-Type: application/json" \
+  -H "x-subject: walkthrough" \
+  -d '{"description": "Initial release"}' | jq .
+```
+
+---
+
+## Step 3 — Create a tenant
+
+A tenant is an isolated config namespace (e.g., a customer, environment, or region).
+
+```bash
+TENANT=$(curl -s -X POST http://localhost:8080/v1/tenants \
+  -H "Content-Type: application/json" \
+  -H "x-subject: walkthrough" \
+  -d "{
+    \"name\": \"my-app\",
+    \"schemaId\": \"${SCHEMA_ID}\",
+    \"schemaVersion\": 1
+  }")
+
+echo "$TENANT" | jq .
+TENANT_ID=$(echo "$TENANT" | jq -r '.tenant.id')
+echo "Tenant ID: $TENANT_ID"
+```
+
+---
+
+## Step 4 — Set config values
+
+### Set individual fields
+
+```bash
+# Enable maintenance mode
+curl -s -X PUT \
+  "http://localhost:8080/v1/tenants/${TENANT_ID}/config/fields/app.maintenance_mode" \
+  -H "Content-Type: application/json" \
+  -H "x-subject: walkthrough" \
+  -d '{"value": {"boolValue": false}, "description": "initial values"}' | jq .
+
+# Set max connections
+curl -s -X PUT \
+  "http://localhost:8080/v1/tenants/${TENANT_ID}/config/fields/app.max_connections" \
+  -H "Content-Type: application/json" \
+  -H "x-subject: walkthrough" \
+  -d '{"value": {"integerValue": "100"}}' | jq .
+```
+
+### Set multiple fields at once
+
+`batchSet` commits all changes as a single config version:
+
+```bash
+curl -s -X POST \
+  "http://localhost:8080/v1/tenants/${TENANT_ID}/config:batchSet" \
+  -H "Content-Type: application/json" \
+  -H "x-subject: walkthrough" \
+  -d "{
+    \"description\": \"set rate limit and support URL\",
+    \"updates\": [
+      {
+        \"fieldPath\": \"app.rate_limit_rps\",
+        \"value\": {\"numberValue\": 500.0}
+      },
+      {
+        \"fieldPath\": \"app.support_url\",
+        \"value\": {\"stringValue\": \"https://support.example.com\"}
+      }
+    ]
+  }" | jq .
+```
+
+---
+
+## Step 5 — Query config
+
+### Full snapshot
+
+```bash
+curl -s \
+  "http://localhost:8080/v1/tenants/${TENANT_ID}/config" \
+  -H "x-subject: walkthrough" | jq .
+```
+
+### Single field
+
+```bash
+curl -s \
+  "http://localhost:8080/v1/tenants/${TENANT_ID}/config/fields/app.rate_limit_rps" \
+  -H "x-subject: walkthrough" | jq .
+```
+
+### Multiple fields in one request
+
+```bash
+curl -s -X POST \
+  "http://localhost:8080/v1/tenants/${TENANT_ID}/config:batchGet" \
+  -H "Content-Type: application/json" \
+  -H "x-subject: walkthrough" \
+  -d '{"fieldPaths": ["app.maintenance_mode", "app.max_connections", "app.rate_limit_rps"]}' | jq .
+```
+
+---
+
+## Step 6 — Watch for changes
+
+Open a second terminal and start a live subscription — the server pushes events whenever config changes:
+
+```bash
+curl -N \
+  "http://localhost:8080/v1/tenants/${TENANT_ID}/config:subscribe" \
+  -H "x-subject: walkthrough"
+```
+
+Back in the first terminal, flip maintenance mode on:
+
+```bash
+curl -s -X PUT \
+  "http://localhost:8080/v1/tenants/${TENANT_ID}/config/fields/app.maintenance_mode" \
+  -H "Content-Type: application/json" \
+  -H "x-subject: walkthrough" \
+  -d '{"value": {"boolValue": true}, "description": "maintenance window"}' | jq .
+```
+
+The subscription terminal receives a `ConfigChange` event within milliseconds — no polling needed.
+
+Press `Ctrl-C` to end the stream.
+
+---
+
+## Step 7 — Explore the audit log
+
+Every write is recorded. Query the full history for your tenant:
+
+```bash
+curl -s \
+  "http://localhost:8080/v1/audit/logs?tenantId=${TENANT_ID}" \
+  -H "x-subject: walkthrough" | jq '.logs[] | {actor, action, fieldPath, newValue, createdAt}'
+```
+
+---
+
+## Clean up
+
+```bash
+docker compose down -v
+```
+
+---
+
+## Next steps
+
+- [Quickstart demo](../quickstart/) — see the SDK and live dashboard in action
+- [OpenDecree docs](https://github.com/opendecree/decree) — full API, CLI, and SDK reference

--- a/rest-walkthrough/docker-compose.yml
+++ b/rest-walkthrough/docker-compose.yml
@@ -1,0 +1,52 @@
+# REST Walkthrough Demo — Docker Compose
+#
+# Minimal stack: postgres + redis + decree-server.
+# No SDK, no custom service — just the REST API on :8080.
+#
+# Ports:
+#   8080 — Decree REST API (the only port you need for this demo)
+
+services:
+  postgres:
+    image: postgres:17
+    environment:
+      POSTGRES_DB: centralconfig
+      POSTGRES_USER: centralconfig
+      POSTGRES_PASSWORD: localdev
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+      - ./seed/init.sql:/docker-entrypoint-initdb.d/001_schema.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U centralconfig"]
+      interval: 2s
+      timeout: 5s
+      retries: 10
+
+  redis:
+    image: redis:7
+    command: redis-server --maxmemory 128mb --maxmemory-policy allkeys-lru
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 2s
+      timeout: 5s
+      retries: 10
+
+  decree-server:
+    image: ghcr.io/opendecree/decree:0.11.0-alpha.1
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    environment:
+      GRPC_PORT: "9090"
+      HTTP_PORT: "8080"
+      DB_WRITE_URL: "postgres://centralconfig:localdev@postgres:5432/centralconfig?sslmode=disable"
+      DB_READ_URL: "postgres://centralconfig:localdev@postgres:5432/centralconfig?sslmode=disable"
+      REDIS_URL: "redis://redis:6379"
+      ENABLE_SERVICES: "schema,config,audit"
+    ports:
+      - "8080:8080"
+
+volumes:
+  pgdata:

--- a/rest-walkthrough/seed/init.sql
+++ b/rest-walkthrough/seed/init.sql
@@ -1,0 +1,125 @@
+
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+-- Field type enum
+CREATE TYPE field_type AS ENUM (
+    'integer',
+    'number',
+    'string',
+    'bool',
+    'time',
+    'duration',
+    'url',
+    'json'
+);
+
+-- Schema definitions
+CREATE TABLE schemas (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name        TEXT NOT NULL UNIQUE,
+    description TEXT,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE schema_versions (
+    id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    schema_id      UUID NOT NULL REFERENCES schemas(id) ON DELETE CASCADE,
+    version        INT NOT NULL,
+    parent_version INT,
+    description    TEXT,
+    checksum       TEXT NOT NULL,
+    published      BOOLEAN NOT NULL DEFAULT false,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE(schema_id, version)
+);
+
+CREATE TABLE schema_fields (
+    id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    schema_version_id UUID NOT NULL REFERENCES schema_versions(id) ON DELETE CASCADE,
+    path              TEXT NOT NULL,
+    field_type        field_type NOT NULL,
+    constraints       JSONB,
+    nullable          BOOLEAN NOT NULL DEFAULT false,
+    deprecated        BOOLEAN NOT NULL DEFAULT false,
+    redirect_to       TEXT,
+    default_value     TEXT,
+    description       TEXT,
+    title             TEXT,
+    example           TEXT,
+    examples          JSONB,
+    external_docs     JSONB,
+    tags              TEXT[],
+    format            TEXT,
+    read_only         BOOLEAN NOT NULL DEFAULT false,
+    write_once        BOOLEAN NOT NULL DEFAULT false,
+    sensitive         BOOLEAN NOT NULL DEFAULT false,
+    UNIQUE(schema_version_id, path)
+);
+
+-- Tenants
+CREATE TABLE tenants (
+    id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name           TEXT NOT NULL UNIQUE,
+    schema_id      UUID NOT NULL REFERENCES schemas(id),
+    schema_version INT NOT NULL,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE tenant_field_locks (
+    tenant_id     UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    field_path    TEXT NOT NULL,
+    locked_values JSONB,
+    PRIMARY KEY (tenant_id, field_path)
+);
+
+-- Config versions
+CREATE TABLE config_versions (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id   UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    version     INT NOT NULL,
+    description TEXT,
+    created_by  TEXT NOT NULL,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE(tenant_id, version)
+);
+
+-- Config values (delta storage — only changed fields per version)
+CREATE TABLE config_values (
+    config_version_id UUID NOT NULL REFERENCES config_versions(id) ON DELETE CASCADE,
+    field_path        TEXT NOT NULL,
+    value             TEXT,
+    checksum          TEXT,
+    description       TEXT,
+    PRIMARY KEY (config_version_id, field_path)
+);
+
+-- Audit: write events
+CREATE TABLE audit_write_log (
+    id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id      UUID NOT NULL,
+    actor          TEXT NOT NULL,
+    action         TEXT NOT NULL,
+    field_path     TEXT,
+    old_value      TEXT,
+    new_value      TEXT,
+    config_version INT,
+    metadata       JSONB,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_audit_write_log_tenant ON audit_write_log(tenant_id, created_at);
+CREATE INDEX idx_audit_write_log_actor ON audit_write_log(actor, created_at);
+
+-- Audit: read usage aggregation
+CREATE TABLE usage_stats (
+    tenant_id    UUID NOT NULL,
+    field_path   TEXT NOT NULL,
+    period_start TIMESTAMPTZ NOT NULL,
+    read_count   BIGINT NOT NULL DEFAULT 0,
+    last_read_by TEXT,
+    last_read_at TIMESTAMPTZ,
+    PRIMARY KEY (tenant_id, field_path, period_start)
+);
+

--- a/rest-walkthrough/test.sh
+++ b/rest-walkthrough/test.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# CI validation for the rest-walkthrough demo.
+# Starts the stack, exercises each API operation, tears down.
+set -euo pipefail
+
+BASE="http://localhost:8080"
+SUBJECT="test-runner"
+
+fail() { echo "FAIL: $1"; docker compose down -v; exit 1; }
+check() { echo "$1" | grep -q "$2" || fail "$3"; }
+
+echo "=== Starting stack ==="
+docker compose up -d
+
+echo "=== Waiting for server ==="
+for i in $(seq 1 30); do
+  curl -sf "${BASE}/v1/server/info" -H "x-subject: ${SUBJECT}" >/dev/null && break
+  [ "$i" = "30" ] && fail "server never became ready"
+  sleep 2
+done
+
+echo "=== Create schema ==="
+SCHEMA=$(curl -sf -X POST "${BASE}/v1/schemas" \
+  -H "Content-Type: application/json" \
+  -H "x-subject: ${SUBJECT}" \
+  -d '{
+    "name": "app-config",
+    "description": "CI test schema",
+    "fields": [
+      {"path": "app.maintenance_mode", "type": "FIELD_TYPE_BOOL"},
+      {"path": "app.max_connections",  "type": "FIELD_TYPE_INT"},
+      {"path": "app.rate_limit_rps",   "type": "FIELD_TYPE_NUMBER"},
+      {"path": "app.support_url",      "type": "FIELD_TYPE_STRING"}
+    ]
+  }')
+SCHEMA_ID=$(echo "$SCHEMA" | python3 -c "import sys,json; print(json.load(sys.stdin)['schema']['id'])")
+echo "Schema ID: $SCHEMA_ID"
+
+echo "=== Publish schema ==="
+curl -sf -X POST "${BASE}/v1/schemas/${SCHEMA_ID}/publish" \
+  -H "Content-Type: application/json" \
+  -H "x-subject: ${SUBJECT}" \
+  -d '{"description": "CI publish"}' >/dev/null
+
+echo "=== Create tenant ==="
+TENANT=$(curl -sf -X POST "${BASE}/v1/tenants" \
+  -H "Content-Type: application/json" \
+  -H "x-subject: ${SUBJECT}" \
+  -d "{\"name\": \"ci-tenant\", \"schemaId\": \"${SCHEMA_ID}\", \"schemaVersion\": 1}")
+TENANT_ID=$(echo "$TENANT" | python3 -c "import sys,json; print(json.load(sys.stdin)['tenant']['id'])")
+echo "Tenant ID: $TENANT_ID"
+
+echo "=== Set individual fields ==="
+curl -sf -X PUT "${BASE}/v1/tenants/${TENANT_ID}/config/fields/app.maintenance_mode" \
+  -H "Content-Type: application/json" \
+  -H "x-subject: ${SUBJECT}" \
+  -d '{"value": {"boolValue": false}, "description": "ci init"}' >/dev/null
+
+curl -sf -X PUT "${BASE}/v1/tenants/${TENANT_ID}/config/fields/app.max_connections" \
+  -H "Content-Type: application/json" \
+  -H "x-subject: ${SUBJECT}" \
+  -d '{"value": {"integerValue": "100"}}' >/dev/null
+
+echo "=== Batch set ==="
+curl -sf -X POST "${BASE}/v1/tenants/${TENANT_ID}/config:batchSet" \
+  -H "Content-Type: application/json" \
+  -H "x-subject: ${SUBJECT}" \
+  -d "{
+    \"description\": \"ci batch\",
+    \"updates\": [
+      {\"fieldPath\": \"app.rate_limit_rps\", \"value\": {\"numberValue\": 500.0}},
+      {\"fieldPath\": \"app.support_url\",    \"value\": {\"stringValue\": \"https://example.com\"}}
+    ]
+  }" >/dev/null
+
+echo "=== Get full config ==="
+CONFIG=$(curl -sf "${BASE}/v1/tenants/${TENANT_ID}/config" -H "x-subject: ${SUBJECT}")
+check "$CONFIG" "app.maintenance_mode" "config missing maintenance_mode"
+check "$CONFIG" "app.rate_limit_rps"   "config missing rate_limit_rps"
+echo "Full config: OK"
+
+echo "=== Get single field ==="
+FIELD=$(curl -sf "${BASE}/v1/tenants/${TENANT_ID}/config/fields/app.max_connections" \
+  -H "x-subject: ${SUBJECT}")
+check "$FIELD" "max_connections" "single field response missing path"
+echo "Single field: OK"
+
+echo "=== Batch get ==="
+BATCH=$(curl -sf -X POST "${BASE}/v1/tenants/${TENANT_ID}/config:batchGet" \
+  -H "Content-Type: application/json" \
+  -H "x-subject: ${SUBJECT}" \
+  -d '{"fieldPaths": ["app.maintenance_mode", "app.max_connections"]}')
+check "$BATCH" "maintenance_mode" "batch get missing maintenance_mode"
+check "$BATCH" "max_connections"  "batch get missing max_connections"
+echo "Batch get: OK"
+
+echo "=== Audit log ==="
+AUDIT=$(curl -sf "${BASE}/v1/audit/logs?tenantId=${TENANT_ID}" -H "x-subject: ${SUBJECT}")
+check "$AUDIT" "app.maintenance_mode" "audit log missing write event"
+echo "Audit log: OK"
+
+echo "=== All checks passed ==="
+
+echo "=== Tearing down ==="
+docker compose down -v


### PR DESCRIPTION
## Summary

- Delivers a self-contained REST walkthrough so evaluators can explore the full API without installing any language runtime or SDK
- Covers the complete lifecycle: create schema → publish → create tenant → set values (individual and batch) → query → watch live changes via SSE → audit log
- Adds a `test.sh` that exercises every step end-to-end for CI validation

## Test plan

- [ ] `docker compose up -d` starts cleanly with `decree-server` on `:8080`
- [ ] All curl commands in `README.md` return expected JSON shapes
- [ ] `test.sh` exits 0 end-to-end
- [ ] Subscribe SSE stream receives a `ConfigChange` event when a field is mutated in a second terminal
- [ ] `docker compose down -v` tears down cleanly

Closes #2