### PR TITLE
feat(quickstart): rewrite as multi-step decoupled-seed tutorial

### DIFF
--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -4,80 +4,142 @@
 
 ## What you'll learn
 
-- How a service reads typed config values via the Go SDK
-- How config changes propagate instantly via WebSocket (no polling, no restarts)
-- How the admin panel lets non-technical users manage config without touching code
-- How schema files ship with your deployment and seed automatically on startup
+This tutorial shows one of OpenDecree's core ideas: **schema and config have different deployment lifecycles**.
+
+- The schema ships with the application — it's owned by the engineering team and deployed with the service.
+- Each tenant provisions its own config independently — against the published schema, without touching the schema definition.
+
+This separation lets N tenants share one schema while keeping their config values completely independent.
 
 ## Prerequisites
 
 - Docker and Docker Compose
+- (Optional) the `decree` CLI for step-by-step exploration
 
-## Run it
+## Quick start (copy-paste)
 
 ```bash
-docker compose up --build
+./run.sh
 ```
 
 Then open:
 - **[http://localhost:4000](http://localhost:4000)** — Payroll Service dashboard
 - **[http://localhost:3000](http://localhost:3000)** — Admin panel
 
+## Step-by-step walkthrough
+
+The same four steps `run.sh` executes, explained in detail.
+
+### Step 1 — App deploys the schema
+
+The schema is a deployment artifact. It ships with the application and is published once per release — independently of any tenant or config values.
+
+```bash
+decree seed payroll.schema.seed.yaml --auto-publish
+```
+
+`payroll.schema.seed.yaml` contains only a `schema` section — no `tenant`, no `config`. This is intentional: the application team owns the schema definition; tenants have no role in it.
+
+**Why it matters:** When you upgrade the application, you publish a new schema version. Tenants can migrate to it on their own schedule. Their config files don't change — only the `schema_version` binding changes.
+
+### Step 2 — First tenant (`acme`) provisions its config
+
+Acme Corp's deployment pipeline seeds its own config. The file references the schema by name — it does not redeclare fields or constraints.
+
+```bash
+decree seed org1.config.seed.yaml
+```
+
+`org1.config.seed.yaml` has a `tenant` section (with `schema: payroll-service`) and a `config` section. The `schema_version` field is omitted, which means it binds to whatever version is currently published — the pipeline doesn't need to track schema versions manually.
+
+**Why it matters:** Acme's pipeline is decoupled from the engineering team's release cycle. When a new schema version is published, Acme re-seeds to pick it up — or pins a specific version if they need more time.
+
+### Step 3 — Second tenant (`globex`) onboards
+
+Globex Corp is a new customer. Their team copies `org1.config.seed.yaml`, edits a few values, and seeds their own config.
+
+```bash
+# Edit org2.config.seed.yaml: change currency to EUR, period_days to 14, etc.
+decree seed org2.config.seed.yaml
+```
+
+Two tenants, one schema, independent config. The schema is not duplicated — Globex references the same `payroll-service` schema that Acme uses.
+
+**Why it matters:** Adding the hundredth tenant is identical to adding the second. The schema is a shared contract; config is per-tenant state.
+
+### Step 4 (optional) — Runtime override on top of the git baseline
+
+The seeded config is the git baseline — config-as-code. But you can layer runtime overrides on top without touching the seed file:
+
+```bash
+decree config set acme payroll.tax_rate 0.22 --server localhost:9090 --subject admin
+```
+
+Watch the Payroll Service dashboard — the tax rate updates instantly via gRPC stream, no restart needed.
+
+**Why it matters:** The seed file captures the stable baseline (reviewed, committed, audited). Operators apply short-lived overrides on top — without breaking the git workflow or requiring a redeployment.
+
 ## What's happening
 
 ```mermaid
 flowchart LR
-    subgraph Demo
-        Seed["Seed (init)"]
+    subgraph "Deploy time"
+        SchemaFile["payroll.schema.seed.yaml"]
+        Org1File["org1.config.seed.yaml"]
+        Org2File["org2.config.seed.yaml"]
+    end
+
+    subgraph "Runtime"
+        Server["Decree Server"]
         Admin["Admin Panel\n:3000"]
         Payroll["Payroll Service\n:4000"]
     end
 
-    Server["Decree Server"]
-
-    Seed -->|"loads seed.yaml"| Server
-    Admin -->|"edit config"| Server
-    Server -->|"gRPC stream"| Payroll
+    SchemaFile -->|"Step 1: decree seed"| Server
+    Org1File -->|"Step 2: decree seed"| Server
+    Org2File -->|"Step 3: decree seed"| Server
+    Admin -->|"Step 4: runtime override"| Server
+    Server -->|"gRPC stream (acme)"| Payroll
     Payroll -->|"WebSocket"| Browser["Your Browser"]
     Admin -.- Browser
 ```
-
-1. **Seed container** loads `seed.yaml` (schema + tenant + initial config) on startup
-2. **Payroll Service** connects to Decree via gRPC, reads config values, and serves a dashboard
-3. **Admin panel** (decree-ui) lets you edit config values in a browser
 
 The Payroll Service uses two SDK patterns:
 - **configclient** — on-demand reads (the "Fetch" buttons)
 - **configwatcher** — live subscription (the auto-updating values)
 
-When you change a value in the admin panel, it flows: Admin → Decree Server → Redis pub/sub → gRPC stream → configwatcher → WebSocket → Dashboard. No restart needed.
+When you change a value in the admin panel (or via CLI), it flows: Admin → Decree Server → Redis pub/sub → gRPC stream → configwatcher → WebSocket → Dashboard. No restart needed.
 
 ## Try it yourself
 
-### Change a config value
+### Change a config value via admin panel
 
-1. Open the [Admin panel](http://localhost:3000) — it lands directly on the config editor
+1. Open the [Admin panel](http://localhost:3000) — it lands on the acme config editor
 2. Click **Edit**, then change `payroll.tax_rate` from `0.025` to `0.1`
 3. Click **Apply** and watch the dashboard — Tax Rate updates instantly from 2.5% to 10.0%
 
 ### Use the CLI
 
 ```bash
-# List current config (use tenant name — no UUID needed)
-docker compose run --rm seed config get-all demo-company \
+# List acme's current config
+docker compose run --rm seed-acme config get-all acme \
   --server decree-server:9090 --subject demo
 
-# Change processing fee via CLI
-docker compose run --rm seed config set demo-company \
+# Apply a runtime override on top of the seeded baseline
+docker compose run --rm seed-acme config set acme \
   payroll.processing_fee 0.99 \
+  --server decree-server:9090 --subject demo
+
+# Check globex's config (different values, same schema)
+docker compose run --rm seed-globex config get-all globex \
   --server decree-server:9090 --subject demo
 ```
 
 ### Evolve the schema
 
-This is the powerful part — edit `seed.yaml` and re-seed to evolve your schema:
+Edit `payroll.schema.seed.yaml` and re-seed to publish a new schema version:
 
-1. Open `seed.yaml` and add a new field:
+1. Add a new field:
    ```yaml
    payroll.bonus_rate:
      type: number
@@ -87,18 +149,14 @@ This is the powerful part — edit `seed.yaml` and re-seed to evolve your schema
        maximum: 1
    ```
 
-2. Re-seed (restart the seed container):
+2. Re-seed the schema:
    ```bash
-   docker compose up seed
+   docker compose run --rm seed-schema
    ```
 
-3. Check the admin panel — the new field appears, ready for configuration
+3. Check the admin panel — the new field appears for both acme and globex, ready for configuration.
 
-Try also:
-- **Add constraints** — make `payroll.period_days` have `maximum: 90` and see validation kick in
-- **Change an enum** — add `"CHF"` to `payroll.currency` enum options
-
-The seed is idempotent — existing values are preserved, new fields are added.
+The seed is idempotent — existing values are preserved, new fields are added, schema version increments only when fields change.
 
 ## Clean up
 
@@ -118,7 +176,9 @@ docker compose down -v
 | postgres | `postgres:17` | (internal) | Schema, config, and audit storage |
 | redis | `redis:7` | (internal) | Cache invalidation + real-time pub/sub |
 | decree-server | `ghcr.io/opendecree/decree:0.11.0-alpha.1` | (internal) | Core config management |
-| seed | `ghcr.io/opendecree/decree-cli:0.11.0-alpha.1` | — | Init container: loads schema from file |
+| seed-schema | `ghcr.io/opendecree/decree-cli:0.11.0-alpha.1` | — | Step 1: imports payroll schema |
+| seed-acme | `ghcr.io/opendecree/decree-cli:0.11.0-alpha.1` | — | Step 2: provisions acme config |
+| seed-globex | `ghcr.io/opendecree/decree-cli:0.11.0-alpha.1` | — | Step 3: provisions globex config |
 | admin | `ghcr.io/opendecree/decree-ui:0.1.0-alpha.1` | 3000 | Admin GUI (nginx + React SPA) |
 | payroll-service | Built from `./service` | 4000 | Demo app (Go + WebSocket) |
 
@@ -139,7 +199,7 @@ docker compose down -v
 |----------|-------|---------|
 | `API_URL` | http://decree-server:8080 | Backend API (proxied by nginx) |
 | `LAYOUT_MODE` | single-tenant | Hides schema/tenant navigation |
-| `TENANT_ID` | demo-company | Pre-selected tenant (slug or UUID) |
+| `TENANT_ID` | acme | Pre-selected tenant (slug or UUID) |
 | `SCHEMA_ID` | (optional) | Pre-select a specific schema |
 | `DEFAULT_ROLE` | admin | Default auth role (admin, not superadmin) |
 | `DEFAULT_SUBJECT` | admin | Default auth identity |
@@ -150,11 +210,13 @@ docker compose down -v
 ### Data Flow
 
 ```
-seed.yaml → decree seed CLI → decree-server (Postgres)
+payroll.schema.seed.yaml → decree seed CLI → decree-server (Postgres)
+org1.config.seed.yaml   → decree seed CLI ↗
+org2.config.seed.yaml   → decree seed CLI ↗
                                     ↓
                               Redis pub/sub
                                     ↓
-                        gRPC Subscribe stream
+                        gRPC Subscribe stream (acme tenant)
                                     ↓
                      payroll-service (configwatcher)
                                     ↓
@@ -176,6 +238,5 @@ Use `docker compose down -v` to destroy all data and start fresh.
 ## Next steps
 
 - [No SDK demo](../rest-walkthrough/) — drive the same API with curl (no Go needed)
-- [Multi-Tenant demo](../multi-tenant/) — same schema, different tenants
 - [OpenDecree docs](https://github.com/opendecree/decree) — full API, CLI, and SDK reference
 - [Go SDK](https://pkg.go.dev/github.com/opendecree/decree/sdk/configclient) — configclient, configwatcher, adminclient

--- a/quickstart/docker-compose.yml
+++ b/quickstart/docker-compose.yml
@@ -1,8 +1,8 @@
 # Payroll Service Demo — Docker Compose
 #
 # Architecture:
-#   postgres + redis → decree-server → seed (init) → payroll-service
-#                                    → admin (UI)
+#   postgres + redis → decree-server → seed-schema → seed-acme + seed-globex
+#                                    → admin (UI)    → payroll-service
 #
 # Ports:
 #   4000 — Payroll Service dashboard (the demo app)
@@ -11,9 +11,9 @@
 #   9090 — Decree gRPC API (used by payroll-service internally)
 #
 # Data flow:
-#   1. seed.yaml defines schema + tenant + initial config
-#   2. Seed container loads it into decree-server on first start
-#   3. Payroll service reads config via gRPC (configclient + configwatcher)
+#   1. payroll.schema.seed.yaml defines the schema — deployed once, shared by all tenants
+#   2. org1.config.seed.yaml and org2.config.seed.yaml define per-tenant config
+#   3. Payroll service reads acme's config via gRPC (configclient + configwatcher)
 #   4. Admin panel edits config via REST → decree-server → Redis pub/sub →
 #      gRPC stream → payroll-service WebSocket → dashboard
 
@@ -69,21 +69,50 @@ services:
     #   - "9090:9090"
     #   - "8080:8080"
 
-  # --- Seed: load schema + tenant + config from file ---
-  # Runs once on startup. The seed is idempotent — safe to re-run after
-  # editing seed.yaml (existing values preserved, new fields added).
-  seed:
+  # --- Step 1: App deploys the schema ---
+  # Schema-only seed. Runs once on startup; idempotent on re-run.
+  # This mirrors what a real app does at deploy time: publish the schema
+  # independently of any tenant or config values.
+  seed-schema:
     image: ghcr.io/opendecree/decree-cli:0.11.0-alpha.1
     depends_on:
       decree-server:
         condition: service_started
     volumes:
-      - ./seed.yaml:/seed.yaml:ro    # Schema definition ships with the deployment
-    # --wait health-checks the server before running (gRPC health protocol).
-    # Seed is idempotent — safe to re-run after editing seed.yaml.
-    command: ["seed", "/seed.yaml",
+      - ./payroll.schema.seed.yaml:/payroll.schema.seed.yaml:ro
+    command: ["seed", "/payroll.schema.seed.yaml",
       "--server", "decree-server:9090", "--subject", "demo-setup",
       "--auto-publish", "--wait", "--wait-timeout", "60s"]
+
+  # --- Step 2: First tenant provisions its config ---
+  # Config-only seed for acme. The tenant references the schema by name;
+  # schema_version is omitted so it binds to the latest published version.
+  # This mirrors what a tenant's deployment pipeline does — independently of
+  # the application that owns the schema.
+  seed-acme:
+    image: ghcr.io/opendecree/decree-cli:0.11.0-alpha.1
+    depends_on:
+      seed-schema:
+        condition: service_completed_successfully
+    volumes:
+      - ./org1.config.seed.yaml:/org1.config.seed.yaml:ro
+    command: ["seed", "/org1.config.seed.yaml",
+      "--server", "decree-server:9090", "--subject", "demo-setup",
+      "--wait", "--wait-timeout", "60s"]
+
+  # --- Step 3: Second tenant onboards ---
+  # Same schema, independent config. Shows N tenants sharing one schema
+  # with per-tenant config values — no schema duplication needed.
+  seed-globex:
+    image: ghcr.io/opendecree/decree-cli:0.11.0-alpha.1
+    depends_on:
+      seed-schema:
+        condition: service_completed_successfully
+    volumes:
+      - ./org2.config.seed.yaml:/org2.config.seed.yaml:ro
+    command: ["seed", "/org2.config.seed.yaml",
+      "--server", "decree-server:9090", "--subject", "demo-setup",
+      "--wait", "--wait-timeout", "60s"]
 
   # --- Admin GUI ---
   # The decree-ui admin panel. Non-technical users manage config here.
@@ -97,7 +126,7 @@ services:
     environment:
       API_URL: http://decree-server:8080  # Proxied by nginx inside the container
       LAYOUT_MODE: single-tenant          # Skip schema/tenant navigation
-      TENANT_ID: demo-company             # Auto-select tenant (slug resolved by server)
+      TENANT_ID: acme                     # Auto-select acme tenant
       DEFAULT_ROLE: admin                 # Default to admin, not superadmin
       DEFAULT_SUBJECT: admin              # Default auth identity
     ports:
@@ -111,11 +140,11 @@ services:
       context: ./service
       dockerfile: Dockerfile
     depends_on:
-      seed:
+      seed-acme:
         condition: service_completed_successfully
     environment:
       DECREE_ADDR: decree-server:9090    # gRPC connection to decree
-      TENANT_ID: demo-company            # Tenant name slug (server resolves to UUID)
+      TENANT_ID: acme                    # Tenant name slug (server resolves to UUID)
       PORT: "4000"
     ports:
       - "4000:4000"

--- a/quickstart/org1.config.seed.yaml
+++ b/quickstart/org1.config.seed.yaml
@@ -1,0 +1,20 @@
+spec_version: v1
+tenant:
+  name: acme
+  schema: payroll-service
+  # schema_version omitted — binds to whatever version is currently published
+config:
+  description: Initial payroll configuration for Acme Corp
+  values:
+    payroll.base_amount:
+      value: 5000
+    payroll.currency:
+      value: "USD"
+    payroll.period_days:
+      value: 30
+    payroll.tax_rate:
+      value: 0.025
+    payroll.overtime_multiplier:
+      value: 1.5
+    payroll.processing_fee:
+      value: 0.30

--- a/quickstart/org2.config.seed.yaml
+++ b/quickstart/org2.config.seed.yaml
@@ -1,0 +1,20 @@
+spec_version: v1
+tenant:
+  name: globex
+  schema: payroll-service
+  # schema_version omitted — binds to whatever version is currently published
+config:
+  description: Initial payroll configuration for Globex Corp
+  values:
+    payroll.base_amount:
+      value: 6500
+    payroll.currency:
+      value: "EUR"
+    payroll.period_days:
+      value: 14
+    payroll.tax_rate:
+      value: 0.035
+    payroll.overtime_multiplier:
+      value: 1.75
+    payroll.processing_fee:
+      value: 0.25

--- a/quickstart/payroll.schema.seed.yaml
+++ b/quickstart/payroll.schema.seed.yaml
@@ -35,20 +35,3 @@ schema:
       description: Per-transaction processing fee
       constraints:
         minimum: 0
-tenant:
-  name: demo-company
-config:
-  description: Initial payroll configuration
-  values:
-    payroll.base_amount:
-      value: 5000
-    payroll.currency:
-      value: "USD"
-    payroll.period_days:
-      value: 30
-    payroll.tax_rate:
-      value: 0.025
-    payroll.overtime_multiplier:
-      value: 1.5
-    payroll.processing_fee:
-      value: 0.30

--- a/quickstart/run.sh
+++ b/quickstart/run.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# End-to-end quickstart: demonstrates decoupled schema + config seeding.
+# Safe to re-run — every step is idempotent.
+set -euo pipefail
+
+COMPOSE="docker compose"
+
+echo "=== Starting infrastructure ==="
+$COMPOSE up -d postgres redis decree-server
+
+echo ""
+echo "=== Step 1: App deploys the schema ==="
+echo "    The schema is a deployment artifact — it ships with the application,"
+echo "    independent of any tenant or config values."
+$COMPOSE run --rm seed-schema
+
+echo ""
+echo "=== Step 2: Acme Corp provisions its config ==="
+echo "    The tenant references the schema by name; it does not redeclare it."
+echo "    schema_version is omitted — binds to the latest published version."
+$COMPOSE run --rm seed-acme
+
+echo ""
+echo "=== Step 3: Globex Corp onboards ==="
+echo "    A second tenant shares the same schema with independent config values."
+$COMPOSE run --rm seed-globex
+
+echo ""
+echo "=== Starting demo services ==="
+$COMPOSE up -d admin payroll-service
+
+echo ""
+echo "=== Done ==="
+echo "    Payroll Service dashboard: http://localhost:4000"
+echo "    Admin panel (acme config): http://localhost:3000"
+echo ""
+echo "    Run 'docker compose down -v' to tear down and remove all data."

--- a/quickstart/test.sh
+++ b/quickstart/test.sh
@@ -1,43 +1,69 @@
 #!/bin/bash
-# Validate the quickstart demo: start, check endpoints, tear down.
+# Validate the quickstart demo: start, check endpoints, verify both tenants, tear down.
 set -euo pipefail
 
-echo "=== Starting demo ==="
-docker compose up -d --wait --build
+COMPOSE="docker compose"
 
-echo "=== Waiting for services ==="
+echo "=== Starting demo ==="
+./run.sh
+
+echo ""
+echo "=== Waiting for payroll service ==="
 for i in $(seq 1 30); do
   curl -sf http://localhost:4000/api/config >/dev/null && break
   sleep 2
 done
 
-echo "=== Testing API endpoints ==="
-# Payroll amount
+echo ""
+echo "=== Testing payroll service endpoints ==="
 AMOUNT=$(curl -sf http://localhost:4000/api/payroll-amount)
 echo "Payroll amount: $AMOUNT"
 echo "$AMOUNT" | grep -q '"amount"' || { echo "FAIL: payroll-amount"; exit 1; }
 
-# Period duration
 PERIOD=$(curl -sf http://localhost:4000/api/period-duration)
 echo "Period duration: $PERIOD"
 echo "$PERIOD" | grep -q '"days"' || { echo "FAIL: period-duration"; exit 1; }
 
-# Config snapshot
 CONFIG=$(curl -sf http://localhost:4000/api/config)
 echo "Config: $CONFIG"
 echo "$CONFIG" | grep -q '"tax_rate"' || { echo "FAIL: config"; exit 1; }
 
-# Dashboard serves HTML
 HTTP_CODE=$(curl -sf -o /dev/null -w "%{http_code}" http://localhost:4000/)
 echo "Dashboard HTTP: $HTTP_CODE"
 [ "$HTTP_CODE" = "200" ] || { echo "FAIL: dashboard"; exit 1; }
 
-# Admin panel
 ADMIN_CODE=$(curl -sf -o /dev/null -w "%{http_code}" http://localhost:3000/)
 echo "Admin HTTP: $ADMIN_CODE"
 [ "$ADMIN_CODE" = "200" ] || { echo "FAIL: admin"; exit 1; }
 
+echo ""
+echo "=== Verifying seed state via CLI ==="
+
+# Both tenants must exist
+ACME_CFG=$($COMPOSE run --rm --no-TTY seed-acme config get-all acme \
+  --server decree-server:9090 --subject test 2>&1)
+echo "Acme config output: $ACME_CFG"
+echo "$ACME_CFG" | grep -q "payroll.tax_rate" || { echo "FAIL: acme config missing"; exit 1; }
+
+GLOBEX_CFG=$($COMPOSE run --rm --no-TTY seed-globex config get-all globex \
+  --server decree-server:9090 --subject test 2>&1)
+echo "Globex config output: $GLOBEX_CFG"
+echo "$GLOBEX_CFG" | grep -q "payroll.tax_rate" || { echo "FAIL: globex config missing"; exit 1; }
+
+# Acme and globex must have different currency values
+echo "$ACME_CFG" | grep -q "USD" || { echo "FAIL: acme currency not USD"; exit 1; }
+echo "$GLOBEX_CFG" | grep -q "EUR" || { echo "FAIL: globex currency not EUR"; exit 1; }
+
+# Verify idempotency: re-running seeds must not create new versions
+echo ""
+echo "=== Verifying idempotency ==="
+$COMPOSE run --rm seed-schema
+$COMPOSE run --rm seed-acme
+$COMPOSE run --rm seed-globex
+echo "Re-seed completed without error."
+
+echo ""
 echo "=== All checks passed ==="
 
 echo "=== Tearing down ==="
-docker compose down -v
+$COMPOSE down -v


### PR DESCRIPTION
## Summary

- Teaches the core OpenDecree value proposition: schema and config have separate deployment lifecycles, each owned by a different team or pipeline
- Replaces the combined `seed.yaml` with three lifecycle-correct files (`payroll.schema.seed.yaml`, `org1.config.seed.yaml`, `org2.config.seed.yaml`) so the demo mirrors how a real multi-tenant deployment works
- Adds `run.sh` for copy-paste users and a step-by-step README that explains the *why* at each step, not just the commands

## Test plan

- [ ] `./run.sh` completes without error from a clean state
- [ ] Payroll Service dashboard loads at http://localhost:4000 (acme tenant)
- [ ] Admin panel loads at http://localhost:3000 (acme config)
- [ ] Re-running `./run.sh` is a no-op (idempotency)
- [ ] `docker compose run --rm seed-globex config get-all globex ...` returns EUR config values
- [ ] `docker compose down -v` cleans up all state

Closes #16