### PR TITLE
Add Codespaces support for quickstart and REST walkthrough demos

### DIFF
--- a/.devcontainer/quickstart/devcontainer.json
+++ b/.devcontainer/quickstart/devcontainer.json
@@ -1,0 +1,35 @@
+{
+  "name": "OpenDecree — Quickstart Demo",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
+  },
+  "workspaceFolder": "/workspaces/demos",
+  // Pull pre-built images and build the payroll service on first create.
+  // Prebuilds run this step ahead of time — resume is instant.
+  "postCreateCommand": "cd quickstart && docker compose pull --ignore-buildable && docker compose build && docker compose up -d",
+  "postStartCommand": "cd quickstart && docker compose up -d 2>/dev/null || true",
+  "forwardPorts": [4000, 3000, 8080],
+  "portsAttributes": {
+    "4000": {
+      "label": "Payroll Service",
+      "onAutoForward": "notify"
+    },
+    "3000": {
+      "label": "Admin Panel",
+      "onAutoForward": "notify"
+    },
+    "8080": {
+      "label": "Decree REST API",
+      "onAutoForward": "silent"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": ["ms-azuretools.vscode-docker"],
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash"
+      }
+    }
+  }
+}

--- a/.devcontainer/rest-walkthrough/devcontainer.json
+++ b/.devcontainer/rest-walkthrough/devcontainer.json
@@ -1,0 +1,27 @@
+{
+  "name": "OpenDecree — REST Walkthrough",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
+  },
+  "workspaceFolder": "/workspaces/demos",
+  // Pull images and start the stack — no build step needed (all pre-built images).
+  // Cold start is typically under 60 seconds with prebuilds enabled.
+  "postCreateCommand": "cd rest-walkthrough && docker compose pull && docker compose up -d",
+  "postStartCommand": "cd rest-walkthrough && docker compose up -d 2>/dev/null || true",
+  "forwardPorts": [8080],
+  "portsAttributes": {
+    "8080": {
+      "label": "Decree REST API",
+      "onAutoForward": "notify"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": ["ms-azuretools.vscode-docker"],
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash"
+      }
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -9,6 +9,19 @@ This repo is a collection of hands-on examples that let you experience [OpenDecr
 
 > **Alpha Software** — OpenDecree is under active development. These demos track the latest release and may change between versions.
 
+## Run in Codespaces (no install)
+
+Click a button → browser IDE → running demo. No Docker, no language runtime, no setup.
+
+| Demo | Open in Codespaces |
+|------|--------------------|
+| **[Quickstart](quickstart/)** | [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/opendecree/demos?devcontainer_path=.devcontainer%2Fquickstart%2Fdevcontainer.json) |
+| **[REST Walkthrough](rest-walkthrough/)** | [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/opendecree/demos?devcontainer_path=.devcontainer%2Frest-walkthrough%2Fdevcontainer.json) |
+
+The devcontainer starts decree server, Postgres, and Redis automatically. Ports are forwarded so your browser can reach the running demo.
+
+> **Faster boot:** Repo admins can enable [Codespaces prebuilds](https://docs.github.com/en/codespaces/prebuilding-your-codespaces) in repository Settings → Codespaces. Prebuilds run the image build and `postCreateCommand` ahead of time, reducing cold-start to under 60 seconds.
+
 ## Prerequisites
 
 - **Docker** and **Docker Compose**
@@ -44,6 +57,7 @@ git checkout
 
 - A **README** with what you'll learn, step-by-step walkthrough, and things to try yourself
 - A **docker-compose.yml** that starts everything (decree server, Postgres, Redis)
+- A **devcontainer** so you can run it in GitHub Codespaces with one click
 - A **`test.sh`** script that CI runs to verify the demo works
 - **Cleanup** instructions — `docker compose down -v` and you're back to clean
 

--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -1,5 +1,7 @@
 # Quickstart: Payroll Service
 
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/opendecree/demos?devcontainer_path=.devcontainer%2Fquickstart%2Fdevcontainer.json)
+
 > A fintech microservice that reads its configuration from OpenDecree — with a live dashboard that updates in real time.
 
 ## What you'll learn

--- a/rest-walkthrough/README.md
+++ b/rest-walkthrough/README.md
@@ -1,5 +1,7 @@
 # REST Walkthrough
 
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/opendecree/demos?devcontainer_path=.devcontainer%2Frest-walkthrough%2Fdevcontainer.json)
+
 > Drive the full OpenDecree API with nothing but `curl`. No SDK, no language runtime — just HTTP.
 
 ## What you'll learn


### PR DESCRIPTION
## Summary

- Codespaces is the single biggest first-touch UX unlock: click → browser IDE → running demo in under 60 seconds, no local install or Docker required.
- Adds per-demo devcontainer configurations that automatically start the decree server, Postgres, and Redis stack on create, and restart services on resume.
- Adds "Open in Codespaces" badges to each demo README and to the top-level README, making the zero-install path discoverable.

## Test plan

- [ ] Click quickstart Codespaces button → codespace creates, `postCreateCommand` completes, ports 4000 / 3000 / 8080 forwarded
- [ ] Payroll Service dashboard loads at port 4000; Admin Panel loads at port 3000
- [ ] Click REST Walkthrough Codespaces button → codespace creates, port 8080 forwarded
- [ ] `curl http://localhost:8080/v1/server/info` returns server info in REST Walkthrough codespace
- [ ] Suspend and resume a codespace → `postStartCommand` restarts services, ports still forwarded
- [ ] (Optional) Enable prebuilds in repo settings and verify cold-start is under 60 seconds

Closes #17