### PR TITLE
docs: trim README badges to highest-signal set

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # OpenDecree Demos
 
+[![CI](https://github.com/opendecree/demos/actions/workflows/ci.yml/badge.svg)](https://github.com/opendecree/demos/actions/workflows/ci.yml)
 [![License](https://img.shields.io/github/license/opendecree/demos)](LICENSE)
-[![Project Status: WIP](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
+
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/opendecree/demos?devcontainer_path=.devcontainer%2Fquickstart%2Fdevcontainer.json)
 
 > See what schema-driven config management actually feels like.
 


### PR DESCRIPTION
## Summary
- Drop the repostatus "WIP" badge — the Alpha note already covers status, and "WIP" undersells the project now that demos exist.
- Add a CI badge (workflow exists, wasn't surfaced).
- Add a top-level "Open in GitHub Codespaces" badge linking to the quickstart devcontainer, on its own line, as the primary try-it-now CTA — mirrors the layout used in the other repos.

## Test plan
- [x] Visual check of remaining badge markup renders correctly