### PR TITLE
Ship runnable quickstart, REST walkthrough, and multi-tenant demos

### DIFF
--- a/.agents/context/demos-setup.md
+++ b/.agents/context/demos-setup.md
@@ -9,19 +9,22 @@ Hands-on examples repo for OpenDecree — the "front door" for newcomers. Social
 - **Name:** `opendecree/demos` (not `decree-demos` — already under opendecree org)
 - **Runtime:** demos run against released Docker image, not built from source
 - **Independence:** each demo is self-contained, `docker compose up` from its directory
-- **CI:** starts with structure validation, upgrades to Docker Compose validation when demos land
+- **CI:** one job per shipped demo, runs `test.sh` (which does `docker compose up` + checks + teardown)
 - **No releases:** this repo doesn't publish packages
 
 ## Parent Issue
 
 opendecree/decree#30 — "Create decree-demos repo with end-to-end solution examples"
 
+## Shipped Demos
+
+1. **Quickstart** (`quickstart/`) — single tenant, create schema, set values, watch updates (beginner)
+2. **No SDK (curl only)** (`rest-walkthrough/`) — full REST API walkthrough, zero install (beginner)
+3. **Multi-Tenant** (`multi-tenant/`) — shared schemas, isolated config per tenant (intermediate)
+
 ## Planned Demos
 
-1. **Quickstart** — single tenant, create schema, set values, watch updates (beginner)
-2. **No SDK (curl only)** — full REST API walkthrough, zero install (beginner)
-3. **Pick Your Language** — same scenario in Go, Python, TypeScript (intermediate)
-4. **Multi-Tenant** — shared schemas, isolated config per tenant (intermediate)
+4. **Pick Your Language** — same scenario in Go, Python, TypeScript (intermediate)
 5. **Schema Evolution** — evolve schema safely, migrate tenants (intermediate)
 6. **Config as Code** — version-controlled config with CI/CD (advanced)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 # CI pipeline for OpenDecree demos.
 #
-# Jobs: validate → check (alls-green gate)
-# Expanded as demos are added — each demo gets a validation job.
+# Jobs: one per demo (docker compose up + test.sh) → check (alls-green gate)
+# Each demo runs on its own runner since they share fixed ports.
 
 name: CI
 
@@ -16,8 +16,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  validate:
-    name: Validate
+  quickstart:
+    name: Quickstart
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -26,15 +26,42 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Check demo structure
-        run: |
-          echo "No demos yet — scaffold only."
-          echo "When demos are added, this job validates each demo's structure."
+      - name: Run test.sh
+        working-directory: quickstart
+        run: bash test.sh
+
+  rest-walkthrough:
+    name: REST walkthrough
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run test.sh
+        working-directory: rest-walkthrough
+        run: bash test.sh
+
+  multi-tenant:
+    name: Multi-tenant
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run test.sh
+        working-directory: multi-tenant
+        run: bash test.sh
 
   check:
     name: CI check
     if: always()
-    needs: [validate]
+    needs: [quickstart, rest-walkthrough, multi-tenant]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Hands-on examples for OpenDecree. Each demo is self-contained, runs via Docker C
 
 ## Status
 
-Alpha — scaffold only, no demos yet.
+Alpha — `quickstart`, `rest-walkthrough`, and `multi-tenant` are shipped and CI-tested. Remaining demos planned (see `.agents/context/demos-setup.md`). Everything subject to change.
 
 ## Structure
 

--- a/README.md
+++ b/README.md
@@ -32,16 +32,14 @@ That's it. No language runtimes, no database setup, no fuss.
 
 ## Pick Your Path
 
-> **Coming soon** — demos are being built. Star the repo to get notified!
-
 | Demo | What You'll Learn | Difficulty |
 |------|------------------|------------|
 | **[Quickstart](quickstart/)** | Create a schema, set config values, watch them update live | Beginner |
 | **[No SDK (curl only)](rest-walkthrough/)** | Drive the full REST API with nothing but curl — zero install | Beginner |
-| **[Pick Your Language](multi-language/)** | The same scenario in Go, Python, and TypeScript side by side | Intermediate |
 | **[Multi-Tenant](multi-tenant/)** | Shared schemas, isolated config per tenant | Intermediate |
-| **[Schema Evolution](schema-evolution/)** | Evolve your schema safely — add fields, tighten constraints, migrate tenants | Intermediate |
-| **[Config as Code](config-as-code/)** | Version-controlled config with CI/CD — seed, validate, promote | Advanced |
+| Pick Your Language *(planned)* | The same scenario in Go, Python, and TypeScript side by side | Intermediate |
+| Schema Evolution *(planned)* | Evolve your schema safely — add fields, tighten constraints, migrate tenants | Intermediate |
+| Config as Code *(planned)* | Version-controlled config with CI/CD — seed, validate, promote | Advanced |
 
 ### Just want one demo?
 

--- a/multi-tenant/README.md
+++ b/multi-tenant/README.md
@@ -98,33 +98,46 @@ pricing.free_tier_limit: 50
 
 ### Step 4 — Verify isolation
 
+Look up each tenant's ID (REST endpoints address tenants by UUID, not name):
+
+```bash
+curl -s http://localhost:8080/v1/tenants -H "x-subject: demo-user" | python3 -m json.tool
+```
+
+Note the `id` for `tenant1` and `tenant2`, then export them for the commands below:
+
+```bash
+export TENANT1_ID=<tenant1 id>
+export TENANT2_ID=<tenant2 id>
+```
+
 Read both tenants and confirm their values are independent:
 
 ```bash
 # Tenant 1 — US store
-curl http://localhost:8080/v1/config/tenant1/snapshot
+curl http://localhost:8080/v1/tenants/$TENANT1_ID/config -H "x-subject: demo-user"
 
 # Tenant 2 — EU store
-curl http://localhost:8080/v1/config/tenant2/snapshot
+curl http://localhost:8080/v1/tenants/$TENANT2_ID/config -H "x-subject: demo-user"
 ```
 
 Now change tenant 1's tax rate:
 
 ```bash
-curl -X PUT http://localhost:8080/v1/config/tenant1/values/checkout.tax_rate \
+curl -X PUT http://localhost:8080/v1/tenants/$TENANT1_ID/config/fields/checkout.tax_rate \
   -H "Content-Type: application/json" \
-  -H "X-Decree-Subject: demo-user" \
-  -d '{"value": "0.10"}'
+  -H "x-subject: demo-user" \
+  -d '{"value": {"numberValue": 0.10}, "description": "Runtime override demo"}'
 ```
 
 Read both again — tenant 2 is untouched:
 
 ```bash
-# tenant1 → 0.10 (updated)
-curl http://localhost:8080/v1/config/tenant1/values/checkout.tax_rate
+# tenant1 → 0.1 (updated)
+curl http://localhost:8080/v1/tenants/$TENANT1_ID/config/fields/checkout.tax_rate -H "x-subject: demo-user"
 
-# tenant2 → 0.20 (unchanged)
-curl http://localhost:8080/v1/config/tenant2/values/checkout.tax_rate
+# tenant2 → 0.2 (unchanged)
+curl http://localhost:8080/v1/tenants/$TENANT2_ID/config/fields/checkout.tax_rate -H "x-subject: demo-user"
 ```
 
 **Why it matters:** Config changes are scoped to a single tenant. There is no shared mutable state between tenants — even though they share a schema.
@@ -135,10 +148,10 @@ Try setting an invalid value — the server rejects it:
 
 ```bash
 # Attempt to set currency to an unsupported value (not in enum)
-curl -X PUT http://localhost:8080/v1/config/tenant1/values/checkout.currency \
+curl -X PUT http://localhost:8080/v1/tenants/$TENANT1_ID/config/fields/checkout.currency \
   -H "Content-Type: application/json" \
-  -H "X-Decree-Subject: demo-user" \
-  -d '{"value": "JPY"}'
+  -H "x-subject: demo-user" \
+  -d '{"value": {"stringValue": "JPY"}}'
 # → 400 Bad Request: constraint violation
 ```
 

--- a/multi-tenant/docker-compose.yml
+++ b/multi-tenant/docker-compose.yml
@@ -57,6 +57,7 @@ services:
     environment:
       GRPC_PORT: "9090"
       HTTP_PORT: "8080"
+      INSECURE_LISTEN: "1"             # Plaintext gRPC/HTTP — local demo only
       DB_WRITE_URL: "postgres://centralconfig:localdev@postgres:5432/centralconfig?sslmode=disable"
       DB_READ_URL: "postgres://centralconfig:localdev@postgres:5432/centralconfig?sslmode=disable"
       REDIS_URL: "redis://redis:6379"

--- a/multi-tenant/run.sh
+++ b/multi-tenant/run.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 DECREE_CLI="docker compose run --rm --no-TTY"
 COMPOSE="docker compose"
 SERVER="localhost:8080"
+SUBJECT="demo-user"
 
 echo "=== Starting infrastructure ==="
 $COMPOSE up -d postgres redis decree-server
@@ -40,43 +41,47 @@ $COMPOSE up -d admin
 echo ""
 echo "=== Waiting for decree REST API ==="
 for i in $(seq 1 30); do
-  curl -sf "http://${SERVER}/v1/server/info" >/dev/null 2>&1 && break
+  curl -sf "http://${SERVER}/v1/server/info" -H "x-subject: ${SUBJECT}" >/dev/null 2>&1 && break
   sleep 2
 done
 
 echo ""
+echo "=== Looking up tenant IDs ==="
+TENANTS=$(curl -sf "http://${SERVER}/v1/tenants" -H "x-subject: ${SUBJECT}")
+TENANT1_ID=$(echo "$TENANTS" | python3 -c "import sys,json; print(next(t['id'] for t in json.load(sys.stdin)['tenants'] if t['name']=='tenant1'))")
+TENANT2_ID=$(echo "$TENANTS" | python3 -c "import sys,json; print(next(t['id'] for t in json.load(sys.stdin)['tenants'] if t['name']=='tenant2'))")
+echo "    tenant1: $TENANT1_ID"
+echo "    tenant2: $TENANT2_ID"
+
+echo ""
 echo "=== Reading tenant1 config ==="
 echo "    (US store — USD, 8% tax, 100 free-tier orders)"
-curl -s "http://${SERVER}/v1/config/tenant1/snapshot" | \
-  python3 -m json.tool 2>/dev/null || \
-  curl -s "http://${SERVER}/v1/config/tenant1/snapshot"
+curl -s "http://${SERVER}/v1/tenants/${TENANT1_ID}/config" -H "x-subject: ${SUBJECT}" | \
+  python3 -m json.tool
 
 echo ""
 echo "=== Reading tenant2 config ==="
 echo "    (EU store — EUR, 20% tax, 50 free-tier orders)"
-curl -s "http://${SERVER}/v1/config/tenant2/snapshot" | \
-  python3 -m json.tool 2>/dev/null || \
-  curl -s "http://${SERVER}/v1/config/tenant2/snapshot"
+curl -s "http://${SERVER}/v1/tenants/${TENANT2_ID}/config" -H "x-subject: ${SUBJECT}" | \
+  python3 -m json.tool
 
 echo ""
 echo "=== Demonstrating isolation: changing tenant1 does not affect tenant2 ==="
 echo "    Setting tenant1 checkout.tax_rate to 0.10 (a runtime override)..."
-curl -s -X PUT "http://${SERVER}/v1/config/tenant1/values/checkout.tax_rate" \
+curl -s -X PUT "http://${SERVER}/v1/tenants/${TENANT1_ID}/config/fields/checkout.tax_rate" \
   -H "Content-Type: application/json" \
-  -H "X-Decree-Subject: demo-user" \
-  -d '{"value": "0.10"}' | python3 -m json.tool 2>/dev/null || true
+  -H "x-subject: ${SUBJECT}" \
+  -d '{"value": {"numberValue": 0.10}, "description": "Runtime override demo"}' | python3 -m json.tool
 
 echo ""
 echo "    tenant1 checkout.tax_rate after update:"
-curl -s "http://${SERVER}/v1/config/tenant1/values/checkout.tax_rate" | \
-  python3 -m json.tool 2>/dev/null || \
-  curl -s "http://${SERVER}/v1/config/tenant1/values/checkout.tax_rate"
+curl -s "http://${SERVER}/v1/tenants/${TENANT1_ID}/config/fields/checkout.tax_rate" -H "x-subject: ${SUBJECT}" | \
+  python3 -m json.tool
 
 echo ""
 echo "    tenant2 checkout.tax_rate (unchanged — still 0.20):"
-curl -s "http://${SERVER}/v1/config/tenant2/values/checkout.tax_rate" | \
-  python3 -m json.tool 2>/dev/null || \
-  curl -s "http://${SERVER}/v1/config/tenant2/values/checkout.tax_rate"
+curl -s "http://${SERVER}/v1/tenants/${TENANT2_ID}/config/fields/checkout.tax_rate" -H "x-subject: ${SUBJECT}" | \
+  python3 -m json.tool
 
 echo ""
 echo "=== Done ==="
@@ -84,7 +89,7 @@ echo "    Admin panel (all tenants): http://localhost:3000"
 echo "    REST API:                  http://localhost:8080"
 echo ""
 echo "    Try it:"
-echo "      curl http://localhost:8080/v1/config/tenant1/snapshot"
-echo "      curl http://localhost:8080/v1/config/tenant2/snapshot"
+echo "      curl http://localhost:8080/v1/tenants/${TENANT1_ID}/config -H 'x-subject: ${SUBJECT}'"
+echo "      curl http://localhost:8080/v1/tenants/${TENANT2_ID}/config -H 'x-subject: ${SUBJECT}'"
 echo ""
 echo "    Run 'docker compose down -v' to tear down and remove all data."

--- a/multi-tenant/seed/init.sql
+++ b/multi-tenant/seed/init.sql
@@ -23,14 +23,16 @@ CREATE TABLE schemas (
 );
 
 CREATE TABLE schema_versions (
-    id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    schema_id      UUID NOT NULL REFERENCES schemas(id) ON DELETE CASCADE,
-    version        INT NOT NULL,
-    parent_version INT,
-    description    TEXT,
-    checksum       TEXT NOT NULL,
-    published      BOOLEAN NOT NULL DEFAULT false,
-    created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    id                 UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    schema_id          UUID NOT NULL REFERENCES schemas(id) ON DELETE CASCADE,
+    version            INT NOT NULL,
+    parent_version     INT,
+    description        TEXT,
+    checksum           TEXT NOT NULL,
+    published          BOOLEAN NOT NULL DEFAULT false,
+    dependent_required JSONB NOT NULL DEFAULT '[]',
+    validations        JSONB NOT NULL DEFAULT '[]',
+    created_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
     UNIQUE(schema_id, version)
 );
 

--- a/multi-tenant/test.sh
+++ b/multi-tenant/test.sh
@@ -4,33 +4,40 @@ set -euo pipefail
 
 COMPOSE="docker compose"
 SERVER="localhost:8080"
+SUBJECT="demo-user"
 
 echo "=== Starting demo ==="
 ./run.sh
 
 echo ""
+echo "=== Looking up tenant IDs ==="
+TENANTS=$(curl -sf "http://${SERVER}/v1/tenants" -H "x-subject: ${SUBJECT}")
+TENANT1_ID=$(echo "$TENANTS" | python3 -c "import sys,json; print(next(t['id'] for t in json.load(sys.stdin)['tenants'] if t['name']=='tenant1'))")
+TENANT2_ID=$(echo "$TENANTS" | python3 -c "import sys,json; print(next(t['id'] for t in json.load(sys.stdin)['tenants'] if t['name']=='tenant2'))")
+
+echo ""
 echo "=== Verifying tenant1 config ==="
-T1=$(curl -sf "http://${SERVER}/v1/config/tenant1/snapshot")
+T1=$(curl -sf "http://${SERVER}/v1/tenants/${TENANT1_ID}/config" -H "x-subject: ${SUBJECT}")
 echo "tenant1 snapshot: $T1"
 echo "$T1" | grep -q "checkout.currency" || { echo "FAIL: tenant1 missing checkout.currency"; exit 1; }
 echo "$T1" | grep -q "USD" || { echo "FAIL: tenant1 currency should be USD"; exit 1; }
 
 echo ""
 echo "=== Verifying tenant2 config ==="
-T2=$(curl -sf "http://${SERVER}/v1/config/tenant2/snapshot")
+T2=$(curl -sf "http://${SERVER}/v1/tenants/${TENANT2_ID}/config" -H "x-subject: ${SUBJECT}")
 echo "tenant2 snapshot: $T2"
 echo "$T2" | grep -q "checkout.currency" || { echo "FAIL: tenant2 missing checkout.currency"; exit 1; }
 echo "$T2" | grep -q "EUR" || { echo "FAIL: tenant2 currency should be EUR"; exit 1; }
 
 echo ""
 echo "=== Verifying tenant isolation (different tax rates) ==="
-T1_TAX=$(curl -sf "http://${SERVER}/v1/config/tenant1/values/checkout.tax_rate")
-T2_TAX=$(curl -sf "http://${SERVER}/v1/config/tenant2/values/checkout.tax_rate")
+T1_TAX=$(curl -sf "http://${SERVER}/v1/tenants/${TENANT1_ID}/config/fields/checkout.tax_rate" -H "x-subject: ${SUBJECT}")
+T2_TAX=$(curl -sf "http://${SERVER}/v1/tenants/${TENANT2_ID}/config/fields/checkout.tax_rate" -H "x-subject: ${SUBJECT}")
 echo "tenant1 tax_rate: $T1_TAX"
 echo "tenant2 tax_rate: $T2_TAX"
 # tenant1 was updated to 0.10 by run.sh; tenant2 must still be 0.20
-echo "$T1_TAX" | grep -q "0.10" || { echo "FAIL: tenant1 tax_rate should be 0.10 after override"; exit 1; }
-echo "$T2_TAX" | grep -q "0.20" || { echo "FAIL: tenant2 tax_rate should be 0.20 (unchanged)"; exit 1; }
+echo "$T1_TAX" | grep -q "0.1" || { echo "FAIL: tenant1 tax_rate should be 0.1 after override"; exit 1; }
+echo "$T2_TAX" | grep -q "0.2" || { echo "FAIL: tenant2 tax_rate should be 0.2 (unchanged)"; exit 1; }
 
 echo ""
 echo "=== Verifying idempotency ==="

--- a/quickstart/docker-compose.yml
+++ b/quickstart/docker-compose.yml
@@ -59,6 +59,7 @@ services:
     environment:
       GRPC_PORT: "9090"                # SDK and CLI connect here
       HTTP_PORT: "8080"                # Admin UI and REST clients connect here
+      INSECURE_LISTEN: "1"             # Plaintext gRPC/HTTP — local demo only
       DB_WRITE_URL: "postgres://centralconfig:localdev@postgres:5432/centralconfig?sslmode=disable"
       DB_READ_URL: "postgres://centralconfig:localdev@postgres:5432/centralconfig?sslmode=disable"
       REDIS_URL: "redis://redis:6379"

--- a/quickstart/seed/init.sql
+++ b/quickstart/seed/init.sql
@@ -23,14 +23,16 @@ CREATE TABLE schemas (
 );
 
 CREATE TABLE schema_versions (
-    id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    schema_id      UUID NOT NULL REFERENCES schemas(id) ON DELETE CASCADE,
-    version        INT NOT NULL,
-    parent_version INT,
-    description    TEXT,
-    checksum       TEXT NOT NULL,
-    published      BOOLEAN NOT NULL DEFAULT false,
-    created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    id                 UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    schema_id          UUID NOT NULL REFERENCES schemas(id) ON DELETE CASCADE,
+    version            INT NOT NULL,
+    parent_version     INT,
+    description        TEXT,
+    checksum           TEXT NOT NULL,
+    published          BOOLEAN NOT NULL DEFAULT false,
+    dependent_required JSONB NOT NULL DEFAULT '[]',
+    validations        JSONB NOT NULL DEFAULT '[]',
+    created_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
     UNIQUE(schema_id, version)
 );
 

--- a/quickstart/service/go.mod
+++ b/quickstart/service/go.mod
@@ -4,14 +4,16 @@ go 1.24.0
 
 require (
 	github.com/coder/websocket v1.8.14
-	github.com/opendecree/decree/api v0.11.0-alpha.1
-	github.com/opendecree/decree/sdk/configclient v0.11.0-alpha.1
 	github.com/opendecree/decree/sdk/configwatcher v0.11.0-alpha.1
+	github.com/opendecree/decree/sdk/grpctransport v0.11.0-alpha.1
 	google.golang.org/grpc v1.80.0
 )
 
 require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
+	github.com/opendecree/decree/api v0.11.0-alpha.1 // indirect
+	github.com/opendecree/decree/sdk/adminclient v0.11.0-alpha.1 // indirect
+	github.com/opendecree/decree/sdk/configclient v0.11.0-alpha.1 // indirect
 	golang.org/x/net v0.49.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/text v0.34.0 // indirect

--- a/quickstart/service/go.sum
+++ b/quickstart/service/go.sum
@@ -16,10 +16,14 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 h1:HWRh5R2+9EifMyIHV7ZV+MIZqgz
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0/go.mod h1:JfhWUomR1baixubs02l85lZYYOm7LV6om4ceouMv45c=
 github.com/opendecree/decree/api v0.11.0-alpha.1 h1:NRTYQdN4b3U/tVpxLhLtiSzKabN5MyNzw1uvwgUKRY8=
 github.com/opendecree/decree/api v0.11.0-alpha.1/go.mod h1:h/1GcY3Ff65lQmcTz8h8vwUEqRaqtZDcoZq9LPUaXYc=
+github.com/opendecree/decree/sdk/adminclient v0.11.0-alpha.1 h1:MzABXxKxQGH31kly3xigLW6317oa1TwCTqrjQ2gfTeo=
+github.com/opendecree/decree/sdk/adminclient v0.11.0-alpha.1/go.mod h1:KxurQRoSE+A60j9JC9nQsamX+5UDGe961gGwDL++35U=
 github.com/opendecree/decree/sdk/configclient v0.11.0-alpha.1 h1:SxCEd1C27C+x/gcPBvJHqbDxwkEx9S4aiIFhVmRxdTM=
 github.com/opendecree/decree/sdk/configclient v0.11.0-alpha.1/go.mod h1:kktnaLDkC1ZyekfNTXl0j07M2J4EoDcAPr93+DgOCQk=
 github.com/opendecree/decree/sdk/configwatcher v0.11.0-alpha.1 h1:nrB4Wcn/bkkCbrN/no091q0qKWkpHH3DcF0iQO4+MKQ=
 github.com/opendecree/decree/sdk/configwatcher v0.11.0-alpha.1/go.mod h1:kpAuP0bib3y/M5MDmvahA+eJGS60lfxZsT2IbJulhXc=
+github.com/opendecree/decree/sdk/grpctransport v0.11.0-alpha.1 h1:kHO+dIYWW/TbBQg5OWv6sfIcS0PsyoRRJI6V3RIIXSs=
+github.com/opendecree/decree/sdk/grpctransport v0.11.0-alpha.1/go.mod h1:e5EvfpYyAT+Azqlt87a52++LJT7s+eJNphwwoAC7A3I=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/otel v1.41.0 h1:YlEwVsGAlCvczDILpUXpIpPSL/VPugt7zHThEMLce1c=

--- a/quickstart/service/main.go
+++ b/quickstart/service/main.go
@@ -19,9 +19,8 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
-	pb "github.com/opendecree/decree/api/centralconfig/v1"
-	"github.com/opendecree/decree/sdk/configclient"
 	"github.com/opendecree/decree/sdk/configwatcher"
+	"github.com/opendecree/decree/sdk/grpctransport"
 )
 
 func main() {
@@ -51,15 +50,10 @@ func run() error {
 	log.Printf("Using tenant: %s", tenantID)
 
 	// --- Config client for on-demand reads ---
-	client := configclient.New(
-		pb.NewConfigServiceClient(conn),
-		configclient.WithSubject("payroll-service"),
-	)
+	client := grpctransport.NewConfigClient(conn, grpctransport.WithSubject("payroll-service"))
 
 	// --- Config watcher for live values ---
-	w := configwatcher.New(conn, tenantID,
-		configwatcher.WithSubject("payroll-service"),
-	)
+	w := grpctransport.NewWatcher(conn, tenantID, grpctransport.WithSubject("payroll-service"))
 	taxRate := w.Float("payroll.tax_rate", 0.025)
 	overtimeMul := w.Float("payroll.overtime_multiplier", 1.5)
 	processingFee := w.Float("payroll.processing_fee", 0.30)

--- a/rest-walkthrough/README.md
+++ b/rest-walkthrough/README.md
@@ -86,7 +86,7 @@ Publishing locks the version and makes it available for tenant assignment.
 curl -s -X POST "http://localhost:8080/v1/schemas/${SCHEMA_ID}/publish" \
   -H "Content-Type: application/json" \
   -H "x-subject: walkthrough" \
-  -d '{"description": "Initial release"}' | jq .
+  -d '{"version": 1}' | jq .
 ```
 
 ---

--- a/rest-walkthrough/docker-compose.yml
+++ b/rest-walkthrough/docker-compose.yml
@@ -41,6 +41,7 @@ services:
     environment:
       GRPC_PORT: "9090"
       HTTP_PORT: "8080"
+      INSECURE_LISTEN: "1"             # Plaintext gRPC/HTTP — local demo only
       DB_WRITE_URL: "postgres://centralconfig:localdev@postgres:5432/centralconfig?sslmode=disable"
       DB_READ_URL: "postgres://centralconfig:localdev@postgres:5432/centralconfig?sslmode=disable"
       REDIS_URL: "redis://redis:6379"

--- a/rest-walkthrough/seed/init.sql
+++ b/rest-walkthrough/seed/init.sql
@@ -23,14 +23,16 @@ CREATE TABLE schemas (
 );
 
 CREATE TABLE schema_versions (
-    id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    schema_id      UUID NOT NULL REFERENCES schemas(id) ON DELETE CASCADE,
-    version        INT NOT NULL,
-    parent_version INT,
-    description    TEXT,
-    checksum       TEXT NOT NULL,
-    published      BOOLEAN NOT NULL DEFAULT false,
-    created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    id                 UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    schema_id          UUID NOT NULL REFERENCES schemas(id) ON DELETE CASCADE,
+    version            INT NOT NULL,
+    parent_version     INT,
+    description        TEXT,
+    checksum           TEXT NOT NULL,
+    published          BOOLEAN NOT NULL DEFAULT false,
+    dependent_required JSONB NOT NULL DEFAULT '[]',
+    validations        JSONB NOT NULL DEFAULT '[]',
+    created_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
     UNIQUE(schema_id, version)
 );
 

--- a/rest-walkthrough/test.sh
+++ b/rest-walkthrough/test.sh
@@ -40,7 +40,7 @@ echo "=== Publish schema ==="
 curl -sf -X POST "${BASE}/v1/schemas/${SCHEMA_ID}/publish" \
   -H "Content-Type: application/json" \
   -H "x-subject: ${SUBJECT}" \
-  -d '{"description": "CI publish"}' >/dev/null
+  -d '{"version": 1}' >/dev/null
 
 echo "=== Create tenant ==="
 TENANT=$(curl -sf -X POST "${BASE}/v1/tenants" \


### PR DESCRIPTION
## Summary

- quickstart, rest-walkthrough, and multi-tenant were already merged but had never been run end-to-end against a released decree server image — all three were broken.
- decree-server requires `INSECURE_LISTEN=1` to accept plaintext connections in this local-demo setup; without it the server exits immediately with a TLS configuration error.
- Each demo's `seed/init.sql` had a stale `schema_versions` table missing the `dependent_required` and `validations` columns added in `001_initial_schema.sql`, so schema import failed.
- quickstart's payroll-service used an outdated SDK API (`configclient`/`configwatcher` with `WithSubject`) that no longer compiles against `sdk/grpctransport`.
- rest-walkthrough's publish call was missing the required `version` field in the request body.
- multi-tenant's `run.sh`/`test.sh` called non-existent `/v1/config/{name}/snapshot` and `/v1/config/{name}/values/{path}` endpoints instead of `/v1/tenants/{id}/config[...]` with the required `x-subject` header and tenant UUIDs.
- README's "Coming soon" banner is removed and the Pick Your Path table now only links to shipped demos (unshipped rows marked `*(planned)*`).
- CI now runs each demo's `test.sh` as a separate job (one per demo, since they share fixed ports).
- `CLAUDE.md` and `.agents/context/demos-setup.md` updated to reflect shipped status.

## Test plan

- [x] `docker compose up` + `test.sh` passes from a clean checkout for `quickstart/`
- [x] `docker compose up` + `test.sh` passes from a clean checkout for `rest-walkthrough/`
- [x] `docker compose up` + `test.sh` passes from a clean checkout for `multi-tenant/`
- [x] `go build` succeeds for `quickstart/service` after SDK API fix
- [x] CI workflow YAML validated with `yaml.safe_load`
- [x] Codespaces devcontainers (`quickstart`, `rest-walkthrough`) reference the fixed compose files, validated via the same `test.sh` runs

Closes #44