### PR TITLE
chore: bump demo images to decree 0.12.0-alpha.3 + ui 0.2.0-alpha.1

### DIFF
--- a/multi-tenant/README.md
+++ b/multi-tenant/README.md
@@ -215,11 +215,11 @@ docker compose down -v
 |---------|-------|-------|---------|
 | postgres | `postgres:17` | (internal) | Schema, config, and audit storage |
 | redis | `redis:7` | (internal) | Cache invalidation + real-time pub/sub |
-| decree-server | `ghcr.io/opendecree/decree:0.11.0-alpha.1` | 8080 | Core config management |
-| seed-schema | `ghcr.io/opendecree/decree-cli:0.11.0-alpha.1` | — | Step 1: imports saas-ecommerce schema |
-| seed-tenant1 | `ghcr.io/opendecree/decree-cli:0.11.0-alpha.1` | — | Step 2: provisions tenant1 config |
-| seed-tenant2 | `ghcr.io/opendecree/decree-cli:0.11.0-alpha.1` | — | Step 3: provisions tenant2 config |
-| admin | `ghcr.io/opendecree/decree-ui:0.1.0-alpha.1` | 3000 | Admin GUI (multi-tenant mode) |
+| decree-server | `ghcr.io/opendecree/decree:0.12.0-alpha.3` | 8080 | Core config management |
+| seed-schema | `ghcr.io/opendecree/decree-cli:0.12.0-alpha.3` | — | Step 1: imports saas-ecommerce schema |
+| seed-tenant1 | `ghcr.io/opendecree/decree-cli:0.12.0-alpha.3` | — | Step 2: provisions tenant1 config |
+| seed-tenant2 | `ghcr.io/opendecree/decree-cli:0.12.0-alpha.3` | — | Step 3: provisions tenant2 config |
+| admin | `ghcr.io/opendecree/decree-ui:0.2.0-alpha.1` | 3000 | Admin GUI (multi-tenant mode) |
 
 ### Seed files
 

--- a/multi-tenant/docker-compose.yml
+++ b/multi-tenant/docker-compose.yml
@@ -48,7 +48,7 @@ services:
   # The core config management service. Runs database migrations automatically.
   # Exposes gRPC (:9090) for SDKs and CLI, and REST (:8080) for the admin UI / curl.
   decree-server:
-    image: ghcr.io/opendecree/decree:0.11.0-alpha.1
+    image: ghcr.io/opendecree/decree:0.12.0-alpha.3
     depends_on:
       postgres:
         condition: service_healthy
@@ -68,7 +68,7 @@ services:
   # --- Step 1: App deploys the schema ---
   # Schema-only seed. Runs once on startup; idempotent on re-run.
   seed-schema:
-    image: ghcr.io/opendecree/decree-cli:0.11.0-alpha.1
+    image: ghcr.io/opendecree/decree-cli:0.12.0-alpha.3
     depends_on:
       decree-server:
         condition: service_started
@@ -80,7 +80,7 @@ services:
 
   # --- Step 2: Tenant 1 (US store) provisions its config ---
   seed-tenant1:
-    image: ghcr.io/opendecree/decree-cli:0.11.0-alpha.1
+    image: ghcr.io/opendecree/decree-cli:0.12.0-alpha.3
     depends_on:
       seed-schema:
         condition: service_completed_successfully
@@ -93,7 +93,7 @@ services:
   # --- Step 3: Tenant 2 (EU store) onboards ---
   # Same schema, independent config.
   seed-tenant2:
-    image: ghcr.io/opendecree/decree-cli:0.11.0-alpha.1
+    image: ghcr.io/opendecree/decree-cli:0.12.0-alpha.3
     depends_on:
       seed-schema:
         condition: service_completed_successfully
@@ -107,7 +107,7 @@ services:
   # The decree-ui admin panel. Runs in multi-tenant mode so you can switch
   # between tenant1 and tenant2 and see their independent config values.
   admin:
-    image: ghcr.io/opendecree/decree-ui:0.1.0-alpha.1
+    image: ghcr.io/opendecree/decree-ui:0.2.0-alpha.1
     depends_on:
       decree-server:
         condition: service_started

--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -177,11 +177,11 @@ docker compose down -v
 |---------|-------|-------|---------|
 | postgres | `postgres:17` | (internal) | Schema, config, and audit storage |
 | redis | `redis:7` | (internal) | Cache invalidation + real-time pub/sub |
-| decree-server | `ghcr.io/opendecree/decree:0.11.0-alpha.1` | (internal) | Core config management |
-| seed-schema | `ghcr.io/opendecree/decree-cli:0.11.0-alpha.1` | — | Step 1: imports payroll schema |
-| seed-acme | `ghcr.io/opendecree/decree-cli:0.11.0-alpha.1` | — | Step 2: provisions acme config |
-| seed-globex | `ghcr.io/opendecree/decree-cli:0.11.0-alpha.1` | — | Step 3: provisions globex config |
-| admin | `ghcr.io/opendecree/decree-ui:0.1.0-alpha.1` | 3000 | Admin GUI (nginx + React SPA) |
+| decree-server | `ghcr.io/opendecree/decree:0.12.0-alpha.3` | (internal) | Core config management |
+| seed-schema | `ghcr.io/opendecree/decree-cli:0.12.0-alpha.3` | — | Step 1: imports payroll schema |
+| seed-acme | `ghcr.io/opendecree/decree-cli:0.12.0-alpha.3` | — | Step 2: provisions acme config |
+| seed-globex | `ghcr.io/opendecree/decree-cli:0.12.0-alpha.3` | — | Step 3: provisions globex config |
+| admin | `ghcr.io/opendecree/decree-ui:0.2.0-alpha.1` | 3000 | Admin GUI (nginx + React SPA) |
 | payroll-service | Built from `./service` | 4000 | Demo app (Go + WebSocket) |
 
 ### Decree Server Environment Variables

--- a/quickstart/docker-compose.yml
+++ b/quickstart/docker-compose.yml
@@ -50,7 +50,7 @@ services:
   # The core config management service. Runs database migrations automatically.
   # Exposes gRPC (:9090) for SDKs and REST (:8080) for the admin UI / curl.
   decree-server:
-    image: ghcr.io/opendecree/decree:0.11.0-alpha.1
+    image: ghcr.io/opendecree/decree:0.12.0-alpha.3
     depends_on:
       postgres:
         condition: service_healthy
@@ -75,7 +75,7 @@ services:
   # This mirrors what a real app does at deploy time: publish the schema
   # independently of any tenant or config values.
   seed-schema:
-    image: ghcr.io/opendecree/decree-cli:0.11.0-alpha.1
+    image: ghcr.io/opendecree/decree-cli:0.12.0-alpha.3
     depends_on:
       decree-server:
         condition: service_started
@@ -91,7 +91,7 @@ services:
   # This mirrors what a tenant's deployment pipeline does — independently of
   # the application that owns the schema.
   seed-acme:
-    image: ghcr.io/opendecree/decree-cli:0.11.0-alpha.1
+    image: ghcr.io/opendecree/decree-cli:0.12.0-alpha.3
     depends_on:
       seed-schema:
         condition: service_completed_successfully
@@ -105,7 +105,7 @@ services:
   # Same schema, independent config. Shows N tenants sharing one schema
   # with per-tenant config values — no schema duplication needed.
   seed-globex:
-    image: ghcr.io/opendecree/decree-cli:0.11.0-alpha.1
+    image: ghcr.io/opendecree/decree-cli:0.12.0-alpha.3
     depends_on:
       seed-schema:
         condition: service_completed_successfully
@@ -120,7 +120,7 @@ services:
   # LAYOUT_MODE=single-tenant hides the schema/tenant navigation —
   # users just see config fields, not the underlying schema system.
   admin:
-    image: ghcr.io/opendecree/decree-ui:0.1.0-alpha.1
+    image: ghcr.io/opendecree/decree-ui:0.2.0-alpha.1
     depends_on:
       decree-server:
         condition: service_started

--- a/rest-walkthrough/docker-compose.yml
+++ b/rest-walkthrough/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       retries: 10
 
   decree-server:
-    image: ghcr.io/opendecree/decree:0.11.0-alpha.1
+    image: ghcr.io/opendecree/decree:0.12.0-alpha.3
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- Point all three demos (quickstart, rest-walkthrough, multi-tenant) at the newly released images: `decree` + `decree-cli` `0.12.0-alpha.3`, `decree-ui` `0.2.0-alpha.1`.
- Tag bumps only (5 files: 3 compose + 2 READMEs). Deeper demo-content alignment to the redesigned UI is tracked separately.

## Test plan
- [x] No stale image tags remain (grep)
- [x] `docker compose config` validates per demo
- [x] All referenced images confirmed on GHCR

🤖 Generated with [Claude Code](https://claude.com/claude-code)