### PR TITLE
feat: add package.json for self-contained Playwright screenshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Node
+node_modules/
+
 # OS
 .DS_Store
 Thumbs.db

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,6 +118,22 @@ git sparse-checkout set quickstart
 git checkout
 ```
 
+## Regenerating Screenshots
+
+Demo READMEs use screenshots of the admin UI captured by `scripts/screenshots.mjs`. To regenerate them:
+
+```bash
+npm install
+npx playwright install chromium   # one-time browser download
+
+UI_URL=http://localhost:3000 API_URL=http://localhost:8080 \
+  ROLE=superadmin OUT_DIR=assets/screenshots \
+  SHOTS='[{"name":"overview","path":"/"}]' \
+  npm run screenshots
+```
+
+The demo stack must already be running (`./run.sh` or `docker compose up`) so `UI_URL` and `API_URL` are reachable. `SHOTS` is a JSON array of `{name, path, wait?}`; a `{tenantName}` token in a path is replaced with that tenant's UUID looked up via the API.
+
 ## Questions?
 
 Open a [Discussion](https://github.com/opendecree/decree/discussions) in the main repo — that's where the community hangs out.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,76 @@
+{
+	"name": "opendecree-demos",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "opendecree-demos",
+			"devDependencies": {
+				"@playwright/test": "^1.61.0"
+			}
+		},
+		"node_modules/@playwright/test": {
+			"version": "1.61.0",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
+			"integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"playwright": "1.61.0"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/fsevents": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/playwright": {
+			"version": "1.61.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+			"integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"playwright-core": "1.61.0"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"fsevents": "2.3.2"
+			}
+		},
+		"node_modules/playwright-core": {
+			"version": "1.61.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+			"integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"playwright-core": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		}
+	}
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+	"name": "opendecree-demos",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"screenshots": "node scripts/screenshots.mjs"
+	},
+	"devDependencies": {
+		"@playwright/test": "^1.61.0"
+	}
+}

--- a/scripts/screenshots.mjs
+++ b/scripts/screenshots.mjs
@@ -4,12 +4,11 @@
  * Prerequisites: the demo stack is up (`./run.sh`) so the UI is served at
  * UI_URL and the decree REST API at API_URL.
  *
- * Usage (Playwright must be resolvable — e.g. run from a dir that has it, or
- * `npm i -D @playwright/test` in this repo first):
+ * Usage (`npm install` then `npx playwright install chromium` once):
  *   UI_URL=http://localhost:3000 API_URL=http://localhost:8080 \
  *   ROLE=superadmin OUT_DIR=assets/screenshots \
  *   SHOTS='[{"name":"overview","path":"/"}]' \
- *   node scripts/screenshots.mjs
+ *   npm run screenshots
  *
  * SHOTS is a JSON array of {name, path, wait?}. A `{tenantName}` token in a
  * path is replaced with that tenant's UUID (looked up via the API).
@@ -37,9 +36,7 @@ async function tenantMap() {
 const tenants = SHOTS.some((s) => s.path.includes("{")) ? await tenantMap() : new Map();
 mkdirSync(OUT_DIR, { recursive: true });
 
-// CHANNEL=chrome uses the system Chrome/Chromium instead of Playwright's
-// bundled build (handy when `npx playwright install` hasn't been run).
-const browser = await chromium.launch(process.env.CHANNEL ? { channel: process.env.CHANNEL } : {});
+const browser = await chromium.launch();
 const context = await browser.newContext({
 	viewport: { width: 1440, height: Number(process.env.VIEWPORT_H) || 900 },
 	colorScheme: "dark",


### PR DESCRIPTION
## Summary
- Add minimal `package.json` with `@playwright/test` devDependency + `screenshots` npm script
- Drop the `CHANNEL=chrome` system-Chrome workaround in `scripts/screenshots.mjs` now that a real bundled browser is installable
- Document screenshot regeneration steps in CONTRIBUTING.md
- Commit `package-lock.json`, ignore `node_modules/`

## Test plan
- [x] `npm install` succeeds cleanly
- [x] `node --check scripts/screenshots.mjs` passes
- [x] Checked `.github/workflows/` — none reference the script, no CI changes needed
- [ ] CI green

Closes #51