### PR TITLE
fix(docs): correct doc drift across all three demos

### DIFF
--- a/multi-tenant/README.md
+++ b/multi-tenant/README.md
@@ -183,13 +183,13 @@ checkout.express_enabled:
   description: Enable express checkout for this store
 ```
 
-Re-seed the schema — the new field appears for both tenants immediately:
+Re-seed the schema — the new field is added to the schema definition immediately (check `GET /v1/schemas` to see it):
 
 ```bash
 docker compose run --rm seed-schema
 ```
 
-Neither tenant's existing config values are affected. The new field is available to both, ready to be configured.
+Neither tenant's existing config values are affected. The field won't appear in a tenant's `/config` response until that tenant sets a value for it — `/config` only returns explicitly-set values, not the full schema field list.
 
 ## What's happening
 

--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -80,7 +80,7 @@ Two tenants, one schema, independent config. The schema is not duplicated — Gl
 The seeded config is the git baseline — config-as-code. But you can layer runtime overrides on top without touching the seed file:
 
 ```bash
-decree config set acme payroll.tax_rate 0.22 --server localhost:9090 --subject admin
+decree config set acme payroll.tax_rate 0.22 --server localhost:9090 --subject admin --insecure
 ```
 
 Watch the Payroll Service dashboard — the tax rate updates instantly via gRPC stream, no restart needed.

--- a/rest-walkthrough/README.md
+++ b/rest-walkthrough/README.md
@@ -9,7 +9,7 @@
 - How to create a schema and publish it
 - How to create a tenant and set config values
 - How to read individual fields and the full config snapshot
-- How to watch for real-time changes via server-sent events
+- How to watch for real-time changes via a streaming JSON response
 
 ## Prerequisites
 
@@ -198,7 +198,7 @@ curl -s -X POST \
 
 ## Step 6 — Watch for changes
 
-Open a second terminal and start a live subscription — the server pushes events whenever config changes:
+Open a second terminal and start a live subscription — the server streams a chunked JSON response from the gRPC-gateway, pushing a new JSON object whenever config changes:
 
 ```bash
 curl -N \
@@ -216,7 +216,7 @@ curl -s -X PUT \
   -d '{"value": {"boolValue": true}, "description": "maintenance window"}' | jq .
 ```
 
-The subscription terminal receives a `ConfigChange` event within milliseconds — no polling needed.
+The subscription terminal receives a `{"result":{"change":{...}}}` JSON object within milliseconds — no polling needed.
 
 Press `Ctrl-C` to end the stream.
 
@@ -229,7 +229,7 @@ Every write is recorded. Query the full history for your tenant:
 ```bash
 curl -s \
   "http://localhost:8080/v1/audit/logs?tenantId=${TENANT_ID}" \
-  -H "x-subject: walkthrough" -H "x-role: superadmin" | jq '.logs[] | {actor, action, fieldPath, newValue, createdAt}'
+  -H "x-subject: walkthrough" -H "x-role: superadmin" | jq '.entries[] | {actor, action, fieldPath, newValue, createdAt}'
 ```
 
 ---


### PR DESCRIPTION
## Summary
- All three demos were verified live end-to-end (full docker compose run + manual walkthrough of every documented command) to confirm they're current against the 0.12.0-alpha.4 server and 0.2.0-alpha.2 admin UI.
- Found and fixed three concrete inaccuracies surfaced by that verification: a broken jq filter that would fail if a reader ran the documented command, a mislabeled response shape, and a misleading claim about when a newly-added schema field becomes visible.

## Test plan
- [x] quickstart: `./test.sh` passes; manually confirmed `--insecure` flag is required for the runtime-override CLI example since the server runs `INSECURE_LISTEN=1`.
- [x] rest-walkthrough: `./test.sh` passes; manually ran every curl step including audit log query — confirmed response wraps entries under `entries`, not `logs`; confirmed Step 6 streaming response is chunked JSON (`result.change`), not real SSE.
- [x] multi-tenant: `./test.sh` passes; manually confirmed a newly-added schema field appears in `GET /v1/schemas` immediately but not in a tenant's `/config` response until that tenant sets a value.